### PR TITLE
Add prettier-plugin-organize-imports and organize imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "jest-fetch-mock": "^3.0.3",
     "lint-staged": "^11.0.0",
     "mocked-env": "^1.3.5",
-    "prettier": "^2.2.1"
+    "prettier": "^2.2.1",
+    "prettier-plugin-organize-imports": "^2.3.3"
   }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router';
-
 import App from './App';
 
 it('renders without crashing', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,22 @@
 import { Container } from 'hds-react';
 import React, { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Route, Redirect, Switch, useRouteMatch } from 'react-router';
-
+import { Redirect, Route, Switch, useRouteMatch } from 'react-router';
 import './app.scss';
-
-import { StoreState } from './redux';
 import { setClientConfig } from './client';
 import clientConfig from './client/config';
 import { useClient } from './client/hooks';
-import Navbar from './common/navbar/Navbar';
-import Footer from './common/footer/Footer';
-import Stepper from './common/stepper/Stepper';
 import OidcCallback from './client/OidcCallback';
-import FrontPage from './pages/frontPage/FrontPage';
 import { ApiAccessTokenActions } from './client/types';
-import ProfilePage from './pages/profilePage/ProfilePage';
-import LandingPage from './pages/landingPage/LandingPage';
-import { fetchUserProfile } from './redux/actions/helsinkiProfile';
 import { ApiAccessTokenContext } from './common/apiAccessTokenProvider';
+import Footer from './common/footer/Footer';
+import Navbar from './common/navbar/Navbar';
+import Stepper from './common/stepper/Stepper';
+import FrontPage from './pages/frontPage/FrontPage';
+import LandingPage from './pages/landingPage/LandingPage';
+import ProfilePage from './pages/profilePage/ProfilePage';
+import { StoreState } from './redux';
+import { fetchUserProfile } from './redux/actions/helsinkiProfile';
 
 setClientConfig(clientConfig);
 

--- a/src/client/ClientProvider.tsx
+++ b/src/client/ClientProvider.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
-
-import { Client, ClientProps } from './types';
 import { useClient } from './hooks';
+import { Client, ClientProps } from './types';
 
 export interface ClientContextProps {
   readonly client: Client;

--- a/src/client/OidcCallback.tsx
+++ b/src/client/OidcCallback.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Redirect } from 'react-router';
-
 import { useClientCallback } from './hooks';
 
 export type OidcCallbackProps = {

--- a/src/client/hooks.ts
+++ b/src/client/hooks.ts
@@ -1,23 +1,23 @@
 import React, {
-  useEffect,
-  useState,
-  useRef,
-  useCallback,
   createContext,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
 } from 'react';
+import { getClient } from './oidc-react';
 import {
+  ApiAccessTokenActions,
+  ApiFetchError,
   Client,
+  ClientError,
   ClientErrorObject,
   ClientEvent,
   ClientStatus,
   ClientStatusId,
-  ClientError,
-  JWTPayload,
-  ApiAccessTokenActions,
   FetchStatus,
-  ApiFetchError,
+  JWTPayload,
 } from './types';
-import { getClient } from './oidc-react';
 
 export function useClient(): Client {
   const clientRef: React.Ref<Client> = useRef(getClient());

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -3,20 +3,20 @@
 // @ts-ignore
 import to from 'await-handler';
 import {
+  Client,
+  ClientErrorObject,
+  ClientEvent,
   ClientEventId,
+  ClientFactory,
+  ClientProps,
+  ClientStatus,
+  ClientStatusId,
   EventHandlers,
   EventListener,
   EventPayload,
-  Client,
-  ClientFactory,
-  ClientStatusId,
-  ClientStatus,
-  ClientErrorObject,
-  User,
-  JWTPayload,
   FetchError,
-  ClientProps,
-  ClientEvent,
+  JWTPayload,
+  User,
 } from './types';
 
 export function createEventHandling(): EventHandlers {

--- a/src/client/oidc-react.ts
+++ b/src/client/oidc-react.ts
@@ -1,31 +1,29 @@
-import React, { useEffect, useState, useRef } from 'react';
 import Oidc, {
+  User,
   UserManager,
   UserManagerSettings,
   WebStorageStateStore,
-  User,
 } from 'oidc-client';
-
-import {
-  Client,
-  ClientStatus,
-  ClientStatusId,
-  User as ClientUser,
-  ClientEvent,
-  ClientFactory,
-  ClientError,
-  ClientProps,
-} from './types';
-
+import React, { useEffect, useRef, useState } from 'react';
 import {
   createClient,
-  hasValidClientConfig,
+  createClientGetOrLoadUserFunction,
   getClientConfig,
   getLocationBasedUri,
   getTokenUri,
-  createClientGetOrLoadUserFunction,
+  hasValidClientConfig,
 } from '.';
 import { AnyObject } from '../common/types';
+import {
+  Client,
+  ClientError,
+  ClientEvent,
+  ClientFactory,
+  ClientProps,
+  ClientStatus,
+  ClientStatusId,
+  User as ClientUser,
+} from './types';
 
 let client: Client | null = null;
 

--- a/src/common/addressSelector/AddressSelector.tsx
+++ b/src/common/addressSelector/AddressSelector.tsx
@@ -1,16 +1,14 @@
-import React from 'react';
-import { useDispatch } from 'react-redux';
-import { useTranslation } from 'react-i18next';
 import { Button, IconArrowRight, Notification } from 'hds-react';
-
-import './addressSelector.scss';
-
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
+import { STEPPER, UserAddress } from '../../redux';
 import {
   setCurrentStepper,
   setSelectedAddress,
 } from '../../redux/actions/permitCart';
 import Address from './address/Address';
-import { STEPPER, UserAddress } from '../../redux';
+import './addressSelector.scss';
 
 const T_PATH = 'common.addressSelector.AddressSelector';
 

--- a/src/common/addressSelector/address/Address.tsx
+++ b/src/common/addressSelector/address/Address.tsx
@@ -1,20 +1,18 @@
 import classNames from 'classnames';
-import { useDispatch } from 'react-redux';
-import React, { FC, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import {
-  RadioButton,
+  Card,
   IconAngleDown,
   IconAngleUp,
-  Card,
   Notification,
+  RadioButton,
 } from 'hds-react';
-
-import './address.scss';
-
+import React, { FC, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
 import { UserAddress } from '../../../redux';
-import ParkingZonesMap from '../parkingZoneMap/ParkingZonesMap';
 import { setSelectedAddress } from '../../../redux/actions/permitCart';
+import ParkingZonesMap from '../parkingZoneMap/ParkingZonesMap';
+import './address.scss';
 
 const T_PATH = 'common.addressSelector.address.Address';
 

--- a/src/common/addressSelector/parkingZoneMap/ParkingZonesMap.tsx
+++ b/src/common/addressSelector/parkingZoneMap/ParkingZonesMap.tsx
@@ -1,14 +1,12 @@
-import React from 'react';
-import { v4 as uuidv4 } from 'uuid';
 import { FeatureCollection, GeoJsonObject, MultiPolygon } from 'geojson';
 import L, { LatLngExpression } from 'leaflet';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { TileLayer, MapContainer, GeoJSON, Marker, Popup } from 'react-leaflet';
-
-import './parkingZonesMap.css';
-
-import { UserAddress } from '../../../redux';
+import { GeoJSON, MapContainer, Marker, Popup, TileLayer } from 'react-leaflet';
+import { v4 as uuidv4 } from 'uuid';
 import marker from '../../../assets/images/icon_poi_talo-sininen.svg';
+import { UserAddress } from '../../../redux';
+import './parkingZonesMap.css';
 
 const icon = new L.Icon({
   iconUrl: marker,

--- a/src/common/apiAccessTokenProvider.tsx
+++ b/src/common/apiAccessTokenProvider.tsx
@@ -1,5 +1,4 @@
 import React, { FC } from 'react';
-
 import { useApiAccessTokens } from '../client/hooks';
 import { ApiAccessTokenActions } from '../client/types';
 

--- a/src/common/footer/Footer.tsx
+++ b/src/common/footer/Footer.tsx
@@ -1,8 +1,8 @@
 import {
   Footer as HDSFooter,
   IconFacebook,
-  IconTwitter,
   IconInstagram,
+  IconTwitter,
 } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/common/hero/Hero.tsx
+++ b/src/common/hero/Hero.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
-import { useTranslation } from 'react-i18next';
 import React, { CSSProperties, FC } from 'react';
-
+import { useTranslation } from 'react-i18next';
 import './hero.scss';
 
 interface Props {

--- a/src/common/navbar/Navbar.tsx
+++ b/src/common/navbar/Navbar.tsx
@@ -1,9 +1,8 @@
-import { History } from 'history';
 import { Navigation } from 'hds-react';
+import { History } from 'history';
+import React, { Dispatch, SetStateAction, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useLocation } from 'react-router-dom';
-import React, { Dispatch, SetStateAction, useState } from 'react';
-
 import { useClient } from '../../client/hooks';
 
 type Page = '/' | 'apiAccessTokens' | 'userTokens' | 'profile';

--- a/src/common/permit/Permit.tsx
+++ b/src/common/permit/Permit.tsx
@@ -1,15 +1,13 @@
-import React from 'react';
 import { addMonths, format } from 'date-fns';
-import { useTranslation } from 'react-i18next';
 import { Card, IconCheckCircle, IconDocument } from 'hds-react';
-
-import './permit.scss';
-
+import React from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   ParkingDurationType,
   Permit as PermitModel,
   UserAddress,
 } from '../../redux';
+import './permit.scss';
 
 const T_PATH = 'common.permit.Permit';
 

--- a/src/common/purchasedOverview/PurchasedOverview.tsx
+++ b/src/common/purchasedOverview/PurchasedOverview.tsx
@@ -1,14 +1,12 @@
-import React from 'react';
-import { useDispatch } from 'react-redux';
-import { useTranslation } from 'react-i18next';
 import { Button, IconDocument, IconSignout, Notification } from 'hds-react';
-
-import './purchasedOverview.scss';
-
-import Permit from '../permit/Permit';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
 import { useClient } from '../../client/hooks';
+import { Permit as PermitModel, STEPPER, UserAddress } from '../../redux';
 import { setCurrentStepper } from '../../redux/actions/permitCart';
-import { STEPPER, UserAddress, Permit as PermitModel } from '../../redux';
+import Permit from '../permit/Permit';
+import './purchasedOverview.scss';
 
 const T_PATH = 'common.purchasedOverview.PurchasedOverview';
 

--- a/src/common/stepper/Stepper.tsx
+++ b/src/common/stepper/Stepper.tsx
@@ -1,9 +1,8 @@
 import classNames from 'classnames';
-import { v4 as uuidv4 } from 'uuid';
 import { IconCheck } from 'hds-react';
-import { useTranslation } from 'react-i18next';
 import React, { CSSProperties, FC } from 'react';
-
+import { useTranslation } from 'react-i18next';
+import { v4 as uuidv4 } from 'uuid';
 import './stepper.scss';
 
 const T_PATH = 'common.stepper.Stepper';

--- a/src/common/vehicleSelector/VehicleSelector.tsx
+++ b/src/common/vehicleSelector/VehicleSelector.tsx
@@ -1,12 +1,10 @@
+import { Notification, NotificationType } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Notification, NotificationType } from 'hds-react';
-
-import './vehicleSelector.scss';
-
 import { PermitCartState, STEPPER } from '../../redux';
 import PermitPrices from './permitPrices/PermitPrices';
 import RegistrationNumbers from './registrationNumbers/RegistrationNumbers';
+import './vehicleSelector.scss';
 
 const T_PATH = 'common.vehicleSelector.VehicleSelector';
 

--- a/src/common/vehicleSelector/registrationNumbers/RegistrationNumber.tsx
+++ b/src/common/vehicleSelector/registrationNumbers/RegistrationNumber.tsx
@@ -1,11 +1,10 @@
-import { v4 as uuidv4 } from 'uuid';
 import { TextInput } from 'hds-react';
 import React, { useState } from 'react';
-import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-
-import Validate from './validate';
+import { useDispatch } from 'react-redux';
+import { v4 as uuidv4 } from 'uuid';
 import { setRegistration } from '../../../redux/actions/permitCart';
+import Validate from './validate';
 
 const T_PATH = 'common.vehicleSelector.registrationNumbers.RegistrationNumber';
 

--- a/src/common/withAuth.tsx
+++ b/src/common/withAuth.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-
-import { Client } from '../client/types';
 import { useClient } from '../client/hooks';
+import { Client } from '../client/types';
 
 export type WithAuthChildProps = { client: Client };
 

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1,8 +1,7 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-
-import fi from './fi.json';
 import en from './en.json';
+import fi from './fi.json';
 import sv from './sv.json';
 
 i18n.use(initReactI18next).init({

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,16 +1,14 @@
+import { init } from '@sentry/browser';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { init } from '@sentry/browser';
 import { BrowserRouter } from 'react-router-dom';
-
-import './i18n/i18n';
-import './assets/styles/main.scss';
-
 import App from './App';
-import reportWebVitals from './reportWebVitals';
-import StoreProvider from './redux/StoreProvider';
+import './assets/styles/main.scss';
 import { ClientProvider } from './client/ClientProvider';
 import { ApiAccessTokenProvider } from './common/apiAccessTokenProvider';
+import './i18n/i18n';
+import StoreProvider from './redux/StoreProvider';
+import reportWebVitals from './reportWebVitals';
 
 const ENVS_WITH_SENTRY = ['staging', 'production'];
 

--- a/src/pages/frontPage/FrontPage.tsx
+++ b/src/pages/frontPage/FrontPage.tsx
@@ -1,8 +1,11 @@
-import React from 'react';
 import { LoadingSpinner } from 'hds-react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
-
+import AddressSelector from '../../common/addressSelector/AddressSelector';
+import DurationSelector from '../../common/durationSelector/DurationSelector';
 import Hero from '../../common/hero/Hero';
+import PurchasedOverview from '../../common/purchasedOverview/PurchasedOverview';
+import VehicleSelector from '../../common/vehicleSelector/VehicleSelector';
 import {
   PermitCartState,
   ProcessingStatus,
@@ -10,13 +13,7 @@ import {
   TalpaState,
   UserProfile,
 } from '../../redux';
-
 import './frontPage.scss';
-
-import AddressSelector from '../../common/addressSelector/AddressSelector';
-import VehicleSelector from '../../common/vehicleSelector/VehicleSelector';
-import DurationSelector from '../../common/durationSelector/DurationSelector';
-import PurchasedOverview from '../../common/purchasedOverview/PurchasedOverview';
 
 const T_PATH = 'pages.frontPage.FrontPage';
 

--- a/src/pages/landingPage/LandingPage.tsx
+++ b/src/pages/landingPage/LandingPage.tsx
@@ -1,11 +1,9 @@
-import React from 'react';
 import { Button } from 'hds-react';
-import { Container } from 'reactstrap';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
-
-import './landingPage.scss';
-
+import { Container } from 'reactstrap';
 import { useClient } from '../../client/hooks';
+import './landingPage.scss';
 
 const T_PATH = 'pages.landingPage.LandingPage';
 

--- a/src/pages/profilePage/ProfilePage.tsx
+++ b/src/pages/profilePage/ProfilePage.tsx
@@ -1,11 +1,10 @@
 import React, { useContext } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { Card, Container } from 'reactstrap';
-import { useTranslation } from 'react-i18next';
-
-import { StoreState } from '../../redux';
 import { ApiAccessTokenActions } from '../../client/types';
 import { ApiAccessTokenContext } from '../../common/apiAccessTokenProvider';
+import { StoreState } from '../../redux';
 
 const T_PATH = 'pages.profilePage.ProfilePage';
 

--- a/src/redux/StoreProvider.tsx
+++ b/src/redux/StoreProvider.tsx
@@ -1,9 +1,8 @@
+import React, { FC, useEffect } from 'react';
 import { Provider } from 'react-redux';
-import React, { useEffect, FC } from 'react';
-
-import { connected } from './actions/user';
 import { useClient } from '../client/hooks';
-import { store, connectClient } from './store';
+import { connected } from './actions/user';
+import { connectClient, store } from './store';
 
 const StoreProvider: FC<React.PropsWithChildren<unknown>> = ({ children }) => {
   const client = useClient();

--- a/src/redux/actions/helsinkiProfile.ts
+++ b/src/redux/actions/helsinkiProfile.ts
@@ -1,11 +1,10 @@
-import { AnyAction } from 'redux';
+import { ApolloQueryResult } from '@apollo/client/core/types';
 import { loader } from 'graphql.macro';
+import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import actionCreatorFactory from 'typescript-fsa';
-import { ApolloQueryResult } from '@apollo/client/core/types';
-
-import { convertQueryToData, getProfileGqlClient } from '../utils';
 import { ProfileQueryResult, UserProfile } from '../types';
+import { convertQueryToData, getProfileGqlClient } from '../utils';
 import { fetchUserPermits } from './permitCart';
 
 const creator = actionCreatorFactory('helsinkiProfile');

--- a/src/redux/actions/permitCart.ts
+++ b/src/redux/actions/permitCart.ts
@@ -1,10 +1,9 @@
-import { ThunkDispatch } from 'redux-thunk';
+import { ApolloQueryResult } from '@apollo/client/core/types';
+import { loader } from 'graphql.macro';
 import { keyBy } from 'lodash';
 import { AnyAction, Dispatch } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
 import actionCreatorFactory from 'typescript-fsa';
-
-import { loader } from 'graphql.macro';
-import { ApolloQueryResult } from '@apollo/client/core/types';
 import {
   ParkingDurationType,
   ParkingStartType,

--- a/src/redux/actions/talpa.ts
+++ b/src/redux/actions/talpa.ts
@@ -1,8 +1,7 @@
+import axios, { AxiosResponse } from 'axios';
 import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
-import axios, { AxiosResponse } from 'axios';
 import actionCreatorFactory from 'typescript-fsa';
-
 import { Permit, TalpaOrder, UserAddress, UserProfile } from '../types';
 
 const creator = actionCreatorFactory('talpa');

--- a/src/redux/index.ts
+++ b/src/redux/index.ts
@@ -1,2 +1,2 @@
-export * from './types';
 export * from './store';
+export * from './types';

--- a/src/redux/reducers/helsinkiProfile.ts
+++ b/src/redux/reducers/helsinkiProfile.ts
@@ -1,7 +1,6 @@
 import { reducerWithInitialState } from 'typescript-fsa-reducers';
-
-import { HelsinkiUserProfileState, ProcessingStatus } from '../types';
 import { fetchHelsinkiProfileAction } from '../actions/helsinkiProfile';
+import { HelsinkiUserProfileState, ProcessingStatus } from '../types';
 
 const initialState: HelsinkiUserProfileState = {
   profile: {},

--- a/src/redux/reducers/permitCart.ts
+++ b/src/redux/reducers/permitCart.ts
@@ -1,6 +1,4 @@
 import { reducerWithInitialState } from 'typescript-fsa-reducers';
-
-import { PermitCartState, ProcessingStatus } from '../types';
 import {
   addRegistrationAction,
   deleteRegistrationAction,
@@ -14,6 +12,7 @@ import {
   setSelectedAddressAction,
   updateRegistrationAction,
 } from '../actions/permitCart';
+import { PermitCartState, ProcessingStatus } from '../types';
 
 const initialState: PermitCartState = {
   currentStep: 1,

--- a/src/redux/reducers/talpa.ts
+++ b/src/redux/reducers/talpa.ts
@@ -1,7 +1,6 @@
 import { reducerWithInitialState } from 'typescript-fsa-reducers';
-
-import { ProcessingStatus, TalpaState } from '../types';
 import { talpaAction } from '../actions/talpa';
+import { ProcessingStatus, TalpaState } from '../types';
 
 const initialState: TalpaState = {} as TalpaState;
 

--- a/src/redux/reducers/user.ts
+++ b/src/redux/reducers/user.ts
@@ -1,6 +1,6 @@
 import { Reducer } from 'redux';
-import { CONNECTED_ACTION, UserState } from '../types';
 import { Client, ClientEvent, ClientStatus } from '../../client/types';
+import { CONNECTED_ACTION, UserState } from '../types';
 
 const initialState: UserState = {
   user: undefined,

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -6,14 +6,13 @@ import {
   createStore,
 } from 'redux';
 import thunk, { ThunkMiddleware } from 'redux-thunk';
-
-import { StoreState } from './types';
-import userReducer from './reducers/user';
-import talpaReducer from './reducers/talpa';
-import permitCartReducer from './reducers/permitCart';
-import helsinkiProfileReducer from './reducers/helsinkiProfile';
-import { authorized, errorThrown, unauthorized } from './actions/user';
 import { Client, ClientErrorObject, ClientEvent, User } from '../client/types';
+import { authorized, errorThrown, unauthorized } from './actions/user';
+import helsinkiProfileReducer from './reducers/helsinkiProfile';
+import permitCartReducer from './reducers/permitCart';
+import talpaReducer from './reducers/talpa';
+import userReducer from './reducers/user';
+import { StoreState } from './types';
 
 // Ignore: The __REDUX_DEVTOOLS_EXTENSION_COMPOSE__ doesn't seem to have types available.
 interface CustomWindow extends Window {

--- a/src/redux/types.ts
+++ b/src/redux/types.ts
@@ -1,5 +1,4 @@
 import { FeatureCollection, MultiPolygon, Position } from 'geojson';
-
 import {
   ClientErrorObject,
   ClientStatusId,

--- a/src/redux/utils.ts
+++ b/src/redux/utils.ts
@@ -1,8 +1,7 @@
 import { ApolloQueryResult } from '@apollo/client/core/types';
-
 import { getClient } from '../client/oidc-react';
+import { createGraphQLClient, GraphQLClient } from '../graphql/graphqlClient';
 import { ProfileQueryResult, UserProfile } from './types';
-import { GraphQLClient, createGraphQLClient } from '../graphql/graphqlClient';
 
 let profileGqlClient: GraphQLClient;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10228,6 +10228,11 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
+prettier-plugin-organize-imports@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.3.3.tgz#6877bcf8ca02569198d8f419c954a0d90a95de15"
+  integrity sha512-PBOwQ8vEIB2b7B3gCuBG7D+dqsr1fsTR4TSAjNacRVdHJrD0yzgz9grOLPSyfwJm+NUTZLyWeHoZ+1mHaUrk+g==
+
 prettier@^2.2.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"


### PR DESCRIPTION
The plugin uses the `organizeImports` feature of the TypeScript
language service API. This is the same as using the
"Organize Imports" action in VS Code.

No configuration is needed, it's automatically utilized by prettier

no refs