### PR TITLE
Change address extra payment case

### DIFF
--- a/src/common/editPermits/PriceChangePreview.tsx
+++ b/src/common/editPermits/PriceChangePreview.tsx
@@ -139,22 +139,6 @@ const PriceChangePreview: React.FC<PriceChangePreviewProps> = ({
             <div>{t(`${T_PATH}.priceCalcDescription`)}</div>
           </div>
         </div>
-        {priceChangeType === PriceChangeType.HIGHER_PRICE && (
-          <div className="extra-payment">
-            <div className="row">
-              <div>
-                <b>{t(`${T_PATH}.extraPaymentTotal`)}</b>
-              </div>
-              <div>
-                <b>{priceChangeTotal} €</b>
-              </div>
-            </div>
-            <div className="row">
-              <div>{t(`${T_PATH}.extraPaymentVatTotal`)}</div>
-              <div>{priceChangeVatTotal} €</div>
-            </div>
-          </div>
-        )}
         {priceChangeType === PriceChangeType.LOWER_PRICE && (
           <div className="refund">
             <div className="row">

--- a/src/graphql/changeAddress.graphql
+++ b/src/graphql/changeAddress.graphql
@@ -1,5 +1,6 @@
 mutation ChangeAddress($addressId: ID!, $iban: String) {
   changeAddress(addressId: $addressId, iban: $iban) {
     success
+    checkoutUrl
   }
 }

--- a/src/hooks/permitHook.ts
+++ b/src/hooks/permitHook.ts
@@ -176,12 +176,14 @@ const usePermitState = (): PermitActions => {
   const changeAddressRequest = useCallback(
     async (addressId, iban) => {
       setStatus('loading');
-      const { success } = await changeAddress(addressId, iban);
-      if (success) {
+      const { checkoutUrl } = await changeAddress(addressId, iban);
+      if (checkoutUrl) {
+        window.open(`${checkoutUrl}?user=${profile?.id}`, '_self');
+      } else {
         await fetchPermits();
       }
     },
-    [fetchPermits]
+    [fetchPermits, profile]
   );
 
   useEffect(() => {

--- a/src/pages/changeAddress/ChangeAddress.tsx
+++ b/src/pages/changeAddress/ChangeAddress.tsx
@@ -96,10 +96,19 @@ const ChangeAddress = (): React.ReactElement => {
           address={notUsedAddress}
           onCancel={() => navigate(ROUTES.VALID_PERMITS)}
           onConfirm={() => {
-            setStep(ChangeAddressStep.PRICE_PREVIEW);
-            getChangeAddressPriceChanges(notUsedAddress.id).then(changes =>
-              setPriceChangesList(changes)
-            );
+            getChangeAddressPriceChanges(notUsedAddress.id).then(changes => {
+              setPriceChangesList(changes);
+              const changeTotal = changes.reduce(
+                (total, item) =>
+                  total + getPermitPriceTotal(item.priceChanges, 'priceChange'),
+                0
+              );
+              if (changeTotal > 0) {
+                changeAddress(notUsedAddress.id);
+              } else {
+                setStep(ChangeAddressStep.PRICE_PREVIEW);
+              }
+            });
           }}
         />
       )}
@@ -109,13 +118,11 @@ const ChangeAddress = (): React.ReactElement => {
           priceChangesList={priceChangesList}
           onCancel={() => setStep(ChangeAddressStep.ADDRESS)}
           onConfirm={() => {
-            if (priceChangeTotal > 0) {
-              // TODO: extra payment
-            } else if (priceChangeTotal === 0) {
+            if (priceChangeTotal === 0) {
               changeAddress(notUsedAddress.id).then(() =>
                 setStep(ChangeAddressStep.ORDER_REVIEW)
               );
-            } else {
+            } else if (priceChangeTotal < 0) {
               setStep(ChangeAddressStep.REFUND);
             }
           }}

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -89,5 +89,6 @@ export type GetUpdateAddressPriceChangesResult = {
 export type ChangeAddressResult = {
   changeAddress: {
     success: boolean;
+    checkoutUrl?: string;
   };
 };


### PR DESCRIPTION
This PR implements the process to handle the extra payment when the customer changes the address from a cheaper zone to a more expensive one. The extra payment process is done by Talpa and the backend is responsible for sending new order to Talpa and return a checkout URL to frontend.

Refs: PV-339