### PR TITLE
Feat/pv 450

### DIFF
--- a/src/common/permit/Permit.tsx
+++ b/src/common/permit/Permit.tsx
@@ -73,7 +73,9 @@ const Permit = ({
         )
       : '';
   const isProcessing = (permit: PermitModel) =>
-    permit.status === PermitStatus.PAYMENT_IN_PROGRESS && permit.talpaOrderId;
+    (permit.status === PermitStatus.PAYMENT_IN_PROGRESS &&
+      permit.talpaOrderId) ||
+    (permit.status === PermitStatus.DRAFT && permit.isOrderConfirmed);
 
   const removeTemporaryVehicle = async (permitId: string) => {
     await removeTemporaryVehicleFromPermit(permitId).then(() => {

--- a/src/graphql/createPermit.graphql
+++ b/src/graphql/createPermit.graphql
@@ -19,6 +19,7 @@ mutation Mutation($addressId: ID!, $registration: String!) {
     hasRefund
     vehicleChanged
     zoneChanged
+    isOrderConfirmed
     activeTemporaryVehicle {
       id
       startTime

--- a/src/graphql/permits.graphql
+++ b/src/graphql/permits.graphql
@@ -19,6 +19,7 @@ query Query {
     hasRefund
     vehicleChanged
     zoneChanged
+    isOrderConfirmed
     activeTemporaryVehicle {
       id
       startTime

--- a/src/graphql/updatePermit.graphql
+++ b/src/graphql/updatePermit.graphql
@@ -18,6 +18,7 @@ mutation Mutation($input: ParkingPermitInput!, $permitId: ID) {
     hasRefund
     vehicleChanged
     zoneChanged
+    isOrderConfirmed
     activeTemporaryVehicle {
       id
       startTime

--- a/src/hooks/permitHook.ts
+++ b/src/hooks/permitHook.ts
@@ -147,10 +147,12 @@ const usePermitState = (): PermitActions => {
     getDraftPermits: () =>
       permits.filter(permit => permit.status === PermitStatus.DRAFT),
     getValidPermits: () =>
-      permits.filter(permit =>
-        [PermitStatus.VALID, PermitStatus.PAYMENT_IN_PROGRESS].includes(
-          permit.status
-        )
+      permits.filter(
+        permit =>
+          [PermitStatus.VALID, PermitStatus.PAYMENT_IN_PROGRESS].includes(
+            permit.status
+          ) ||
+          (permit.status === PermitStatus.DRAFT && permit.isOrderConfirmed)
       ),
     getChangeAddressPriceChanges,
     changeAddress: (addressId, iban) => changeAddressRequest(addressId, iban),

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -207,6 +207,8 @@
   "pages.temporaryVehicle.TemporaryVehicle.startTime.label": "Start Time",
   "pages.validPermit.ValidPermit.addressChanged.notification.label": "Change of user address",
   "pages.validPermit.ValidPermit.addressChanged.notification.message": "Based on the information provided by Helsinki profile, your address has been changed and thus requires an immediate action to update your address information. Otherwise the account will automatically expire on {{date}} at {{time}}.",
+  "pages.validPermit.ValidPermit.waitingParkkihubi.notification.label": "Permit not yet active",
+  "pages.validPermit.ValidPermit.waitingParkkihubi.notification.message": "Permit is paid and waiting for the permit to be active.",
   "pages.validPermit.ValidPermit.vehicleChanged.notification.label": "Change in vehicle information",
   "pages.validPermit.ValidPermit.vehicleChanged.notification.message": "Based on the information provided by Traficom, you are not the owner or holder of the vehicle associated with your account. Please update your vehicle information. Otherwise the account will automatically expire on {{date}} at {{time}}.",
   "pages.validPermit.deleteOrder": "Delete order",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -209,6 +209,8 @@
   "pages.temporaryVehicle.TemporaryVehicle.startTime.label": "Alkamisaika",
   "pages.validPermit.ValidPermit.addressChanged.notification.label": "Käyttäjän osoitteen muutos",
   "pages.validPermit.ValidPermit.addressChanged.notification.message": "Helsinki-profiilin antamien tietojen perusteella osoitteesi on muuttunut ja vaatii siten välittömiä toimenpiteitä osoitetietojesi päivittämiseksi. Muuten tili vanhenee automaattisesti {{date}} klo {{time}}.",
+  "pages.validPermit.ValidPermit.waitingParkkihubi.notification.label": "Lupa ei ole vielä voimassa",
+  "pages.validPermit.ValidPermit.waitingParkkihubi.notification.message": "Lupa on maksettu ja odottaa luvan voimaantuloa.",
   "pages.validPermit.ValidPermit.deleteOrder": "Päätä tilaus",
   "pages.validPermit.ValidPermit.newOrder": "Lisää toinen ajoneuvo",
   "pages.validPermit.ValidPermit.sectionLabel": "Pysäköintitunnuksesi",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -205,6 +205,8 @@
   "pages.temporaryVehicle.TemporaryVehicle.startTime.label": "Starttid",
   "pages.validPermit.ValidPermit.addressChanged.notification.label": "Ändring av användaradress",
   "pages.validPermit.ValidPermit.addressChanged.notification.message": "Baserat på informationen från Helsingfors-profilen har din adress ändrats och kräver därför en omedelbar åtgärd för att uppdatera din adressinformation. Annars upphör kontot automatiskt den {{date}} kl {{time}}.",
+  "pages.validPermit.ValidPermit.waitingParkkihubi.notification.label": "Tillståndet är ännu inte aktivt",
+  "pages.validPermit.ValidPermit.waitingParkkihubi.notification.message": "Tillstånd är betalt och väntar på att tillståndet ska vara aktivt.",
   "pages.validPermit.ValidPermit.vehicleChanged.notification.label": "Ändring av fordonsinformation",
   "pages.validPermit.ValidPermit.vehicleChanged.notification.message": "Baserat på informationen från Traficom är du inte ägare eller ägare till fordonet som är kopplat till ditt konto. Vänligen uppdatera din fordonsinformation. Annars kommer kontot automatiskt löper ut den {{date}} kl. {{time}}.",
   "pages.validPermit.deleteOrder": "Ta bort beställning",

--- a/src/pages/validPermits/ValidPermits.tsx
+++ b/src/pages/validPermits/ValidPermits.tsx
@@ -49,7 +49,9 @@ const ValidPermits = (): React.ReactElement => {
 
   const address = getAddress();
   const isProcessing = (permit: PermitModel) =>
-    permit.status === PermitStatus.PAYMENT_IN_PROGRESS && permit.talpaOrderId;
+    (permit.status === PermitStatus.PAYMENT_IN_PROGRESS &&
+      permit.talpaOrderId) ||
+    (permit.status === PermitStatus.DRAFT && permit.isOrderConfirmed);
 
   const hasVehicleChanged = (permit: PermitModel) => permit.vehicleChanged;
   const hasAddressChanged = (permit: PermitModel) => permit.zoneChanged;
@@ -57,9 +59,27 @@ const ValidPermits = (): React.ReactElement => {
   return (
     <div className="valid-permit-component">
       <div className="section-label">{t(`${T_PATH}.sectionLabel`)}</div>
-      {validPermits.some(isProcessing) && (
-        <PurchaseNotification validPermits={validPermits} />
+      {validPermits.some(
+        permit =>
+          permit.status === PermitStatus.PAYMENT_IN_PROGRESS &&
+          permit.talpaOrderId
+      ) && <PurchaseNotification validPermits={validPermits} />}
+
+      {validPermits.some(
+        permit =>
+          permit.status === PermitStatus.DRAFT && permit.isOrderConfirmed
+      ) && (
+        <Notification
+          type="alert"
+          className="waitingParkkihubi"
+          label={t(`${T_PATH}.waitingParkkihubi.notification.label`)}>
+          {t(`${T_PATH}.waitingParkkihubi.notification.message`, {
+            date: formatDate(new Date()),
+            time: format(endOfDay(new Date()), 'HH:mm'),
+          })}
+        </Notification>
       )}
+
       {validPermits.some(hasVehicleChanged) && (
         <Notification
           type="alert"

--- a/src/pages/validPermits/validPermits.scss
+++ b/src/pages/validPermits/validPermits.scss
@@ -11,6 +11,7 @@
       }
     }
   }
+  .waitingParkkihubi,
   .vehicleChanged,
   .addressChanged {
     margin-top: var(--spacing-l);

--- a/src/types/permits.ts
+++ b/src/types/permits.ts
@@ -45,6 +45,7 @@ export type Permit = {
   canEndAfterCurrentPeriod: boolean;
   vehicleChanged: boolean;
   zoneChanged: boolean;
+  isOrderConfirmed: boolean;
 };
 
 export type Vehicle = {


### PR DESCRIPTION
## Description

This property is used to know if the last order related to the permit has been paid or not.

## Context

Web-shop need to know if the status of order for the permit has been paid or not so that it can set the UI to a state user won't end up paying multiple times for same permit.

[PV-450](https://helsinkisolutionoffice.atlassian.net/browse/PV-450)

## Manual Testing Instructions for Reviewers

Login to web-shop, create a permit and go through the payment process. Once the payment is done log in the admin panel and check if the order of the permit is confirmed or not. If it's confirmed got the the related permit and mark it as `DRAFT`. Now goto to web-shop and login to system you can see that the UI is grayed out and wont let you to pay for the system again. You can also check in the network response that the permit has now property called `isOrderConfirmed`.

## Screenshots

<img width="999" alt="Screenshot 2022-10-06 at 8 27 34" src="https://user-images.githubusercontent.com/9328930/194224254-ec801900-0f25-4f65-9634-c690e99b3472.png">

