### PR TITLE
Add low-emission consent to change vehicle page

### DIFF
--- a/src/pages/changeVehicle/ChangeVehicle.tsx
+++ b/src/pages/changeVehicle/ChangeVehicle.tsx
@@ -5,6 +5,7 @@ import PriceChangePreview from '../../common/editPermits/PriceChangePreview';
 import Refund from '../../common/editPermits/Refund';
 import { getChangeTotal } from '../../common/editPermits/utils';
 import VehicleDetails from '../../common/editPermits/VehicleDetails';
+import LowEmissionConsent from '../../common/lowEmissionConsent/LowEmissionConsent';
 import { updatePermitVehicle } from '../../graphql/permitGqlClient';
 import { PermitStateContext } from '../../hooks/permitProvider';
 import { UserProfileContext } from '../../hooks/userProfileProvider';
@@ -12,6 +13,7 @@ import {
   ParkingContractType,
   PermitPriceChanges,
   ROUTES,
+  Permit,
   Vehicle,
 } from '../../types';
 
@@ -34,6 +36,9 @@ const ChangeVehicle = (): React.ReactElement => {
   const permitCtx = useContext(PermitStateContext);
   const profileCtx = useContext(UserProfileContext);
   const [vehicle, setVehicle] = useState<Vehicle>();
+
+  const updatePermitData = (payload: Partial<Permit>, permitId?: string) =>
+    permitCtx?.updatePermit(payload, permitId);
 
   const [step, setStep] = useState<ChangeVehicleStep>(
     ChangeVehicleStep.VEHICLE
@@ -115,6 +120,10 @@ const ChangeVehicle = (): React.ReactElement => {
 
   return (
     <div className="change-vehicle-component">
+      <LowEmissionConsent
+        permits={[permit]}
+        updatePermitData={updatePermitData}
+      />
       {step === ChangeVehicleStep.VEHICLE && (
         <VehicleDetails
           permit={permit}


### PR DESCRIPTION
## Description

Add low-emission consent checkbox to change vehicle page.

## Context

It would be more correct to ask low-emission consent on each vehicle change, since the vehicle might have been previously high-emission and thus there would be no way for a user to allow the consent. Add low-emission consent checkbox to change vehicle page to overcome this issue.

Refs: [PV-367](https://helsinkisolutionoffice.atlassian.net/browse/PV-367)
