### PR TITLE
Fix permit start and end times

### DIFF
--- a/src/common/permit/Permit.tsx
+++ b/src/common/permit/Permit.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { addMonths, format } from 'date-fns';
+import { format } from 'date-fns';
 import {
   Button,
   Card,
@@ -62,16 +62,6 @@ const Permit = ({
     )
   );
 
-  const getEndTime = (permit: PermitModel) =>
-    permit.startTime
-      ? format(
-          addMonths(
-            new Date(permit.startTime as string),
-            permit?.monthCount || 0
-          ),
-          dateFormat
-        )
-      : '';
   const isProcessing = (permit: PermitModel) =>
     (permit.status === PermitStatus.PAYMENT_IN_PROGRESS &&
       permit.talpaOrderId) ||
@@ -134,7 +124,7 @@ const Permit = ({
                 {permit.contractType === ParkingContractType.OPEN_ENDED &&
                   t(`${T_PATH}.contractType`)}
                 {permit.contractType !== ParkingContractType.OPEN_ENDED &&
-                  getEndTime(permit)}
+                  format(new Date(permit.endTime as string), dateFormat)}
               </span>
             </div>
           </>

--- a/src/common/permitType/PermitType.tsx
+++ b/src/common/permitType/PermitType.tsx
@@ -112,7 +112,7 @@ const PermitType = ({
               onClick={() =>
                 updatePermitData({
                   startType: ParkingStartType.IMMEDIATELY,
-                  startTime: startOfDay(addDays(new Date(), 1)),
+                  startTime: new Date().toISOString(),
                 })
               }
             />


### PR DESCRIPTION
## Description

Fix permit start and end times.

## Context

- Permit start time selection was incorrectly put to next day at 00:00 in case of "immediately"-selection, now it is set to current date and time.
- Permit-card end time was calculated dynamically by extra logic. Now instead use permit end time directly in case of fixed-period permit.

Fixes: [PV-484](https://helsinkisolutionoffice.atlassian.net/browse/PV-484)

## How Has This Been Tested?

Manually.

## Manual Testing Instructions for Reviewers

Test manually the upper cases.

## Screenshots

![permit-start-time-immediately](https://user-images.githubusercontent.com/2784933/199797581-fa390695-2b02-4a8a-b772-9062dedb6b36.png)

