### PR TITLE
Sort the order of permits with primary first

### DIFF
--- a/src/hooks/permitHook.ts
+++ b/src/hooks/permitHook.ts
@@ -145,7 +145,9 @@ const usePermitState = (): PermitActions => {
     getPermits: () => permits,
     fetchPermits: (): Promise<void> => fetchPermits(),
     getDraftPermits: () =>
-      permits.filter(permit => permit.status === PermitStatus.DRAFT),
+      permits
+        .filter(permit => permit.status === PermitStatus.DRAFT)
+        .sort(a => (a.primaryVehicle ? -1 : 1)),
     getValidPermits: () =>
       permits.filter(
         permit =>


### PR DESCRIPTION
## Description

Order of permits matter in this case since
secondary permits depends on the primary
permit info.

[PV-475](https://helsinkisolutionoffice.atlassian.net/browse/PV-475)

## Manual Testing Instructions for Reviewers

Create two draft permits and add some duration to the both of them. Then go back to previous step and change the primary vehicle.

## Screenshots
![Nov-08-2022 23-09-04](https://user-images.githubusercontent.com/9328930/200676562-9723f337-ee8b-4c9a-9ab4-12a6b06f7120.gif)

