### PR TITLE
Fix the incorrect refund calculations while ending the permit

### DIFF
--- a/src/pages/endPermit/EndPermit.tsx
+++ b/src/pages/endPermit/EndPermit.tsx
@@ -1,4 +1,4 @@
-import { addMonths } from 'date-fns';
+import { intervalToDuration } from 'date-fns';
 import queryString from 'query-string';
 import React, { useContext, useState } from 'react';
 import { Navigate, useLocation, useNavigate } from 'react-router-dom';
@@ -8,8 +8,39 @@ import { getChangeTotal } from '../../common/editPermits/utils';
 import EndPermitResult from '../../common/endPermitResult/EndPermitResult';
 import { PermitStateContext } from '../../hooks/permitProvider';
 import { UserProfileContext } from '../../hooks/userProfileProvider';
-import { EndPermitStep, ROUTES, UserProfile } from '../../types';
+import {
+  EndPermitStep,
+  PermitEndType,
+  Product,
+  ROUTES,
+  UserProfile,
+} from '../../types';
 import './endPermit.scss';
+
+const dateAsNumber = (date: Date | string): number => new Date(date).valueOf();
+
+const getMonthCount = (
+  permitEndStartDate: Date,
+  permitStartTime: string,
+  product: Product
+) => {
+  // It should consider the start time of the permit.
+  // Eg: If permit was bought and started just before the permitEndStartDate
+  // then it should be counted as a full month used and if the start date is in
+  // the future. It should refund the whole month.
+  if (
+    dateAsNumber(permitStartTime) > permitEndStartDate.valueOf() ||
+    dateAsNumber(product.startDate) > permitEndStartDate.valueOf()
+  ) {
+    return product.quantity;
+  }
+
+  const intervalDuration = intervalToDuration({
+    start: new Date(),
+    end: new Date(product.endDate),
+  });
+  return intervalDuration.months || 0;
+};
 
 const EndPermit = (): React.ReactElement => {
   const { search } = useLocation();
@@ -32,22 +63,35 @@ const EndPermit = (): React.ReactElement => {
   const permits = validPermits.filter(p => permitIds?.indexOf(p.id) !== -1);
   const getsRefund = permits.some(p => p.monthsLeft || 0);
 
-  const priceChangesList = permits.map(permit => ({
-    vehicle: permit.vehicle,
-    priceChanges: permit.products.map(product => ({
-      product: product.name,
-      previousPrice: product.unitPrice,
-      newPrice: product.unitPrice,
-      priceChange: product.unitPrice,
-      priceChangeVat: product.vat,
-      startDate: addMonths(
-        new Date(product.startDate),
-        permit.monthsLeft
-      ).toString(),
-      endDate: product.endDate,
-      monthCount: permit.monthsLeft,
-    })),
-  }));
+  const priceChangesList = permits.map(permit => {
+    // User can end the permit today of from the end of current period.
+    const endingOfPermitStartDate =
+      endType === PermitEndType.AFTER_CURRENT_PERIOD
+        ? new Date(permit.currentPeriodEndTime)
+        : new Date();
+    return {
+      vehicle: permit.vehicle,
+      priceChanges: permit.products
+        .filter(
+          product =>
+            endingOfPermitStartDate.valueOf() <= dateAsNumber(product.endDate)
+        )
+        .map(product => ({
+          product: product.name,
+          previousPrice: product.unitPrice,
+          newPrice: product.unitPrice,
+          priceChange: product.unitPrice,
+          priceChangeVat: product.vat * product.unitPrice,
+          startDate: product.startDate,
+          endDate: product.endDate,
+          monthCount: getMonthCount(
+            endingOfPermitStartDate,
+            permit.startTime as string,
+            product
+          ),
+        })),
+    };
+  });
 
   return (
     <div className="end-permit-component">


### PR DESCRIPTION
Refs PV-487

## Description

Refund calculation should consider each product and the quantity used separately. Except the first fully unused product where it needs to calculate the remaining unused quantity by taking into consideration 1 day or hour is equivalent to whole 1 month used.

[PV-487](https://helsinkisolutionoffice.atlassian.net/browse/PV-487)

## Manual Testing Instructions for Reviewers

Login to webshop and buy a fixed permit with some duration and try to end the existing valid permit(Note: If the permit was started even 1 min before the ending date it will reduce whole month and if it's in future it will refund the whole sum.)

## Screenshots
<img width="972" alt="Screenshot 2022-11-11 at 12 12 38" src="https://user-images.githubusercontent.com/9328930/201318403-c3c53119-f4a0-4d99-a5a0-ecff3c9c0138.png">

