### PR TITLE
Remove unnecessary order confirmation dialog

### DIFF
--- a/src/common/editPermits/OrderReview.tsx
+++ b/src/common/editPermits/OrderReview.tsx
@@ -47,9 +47,6 @@ const OrderReview: React.FC<OrderReviewProps> = ({
             email: profile.email,
           })}
         </Notification>
-        <Button className="open-confirmation-btn" theme="black">
-          {t(`${T_PATH}.openConfirmPage`)}
-        </Button>
         <div className="title">{t(`${T_PATH}.title`)}</div>
         <Permit
           address={address}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -46,7 +46,6 @@
   "common.editPermits.OrderReview.notification.info.orderSuccessMessage": "The parking permit is electronic and the parking control identifies a valid ID based on your vehicle's registration number.",
   "common.editPermits.OrderReview.notification.info.orderSuccessTitle": "Order Successful",
   "common.editPermits.OrderReview.notification.info.pendingRefundTitle": "Pending refund",
-  "common.editPermits.OrderReview.openConfirmPage": "Open confirmation page",
   "common.editPermits.OrderReview.title": "Parking permits",
   "common.editPermits.PriceChangePreview.actionBtn.cancel": "Cancel",
   "common.editPermits.PriceChangePreview.actionBtn.continue": "Continue",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -46,7 +46,6 @@
   "common.editPermits.OrderReview.notification.info.orderSuccessMessage": "Pysäköintilupa on sähköinen ja pysäköintivalvonta tunnistaa voimassaolevan tunnuksen ajoneuvosi rekisterinumeron perusteella.",
   "common.editPermits.OrderReview.notification.info.orderSuccessTitle": "Tilaus onnistui",
   "common.editPermits.OrderReview.notification.info.pendingRefundTitle": "Palautus otettu käsittelyyn",
-  "common.editPermits.OrderReview.openConfirmPage": "Avaa vahvistusviesti",
   "common.editPermits.OrderReview.title": "Pysäköintitunnuksesi",
   "common.editPermits.PriceChangePreview.actionBtn.cancel": "Peruuta",
   "common.editPermits.PriceChangePreview.actionBtn.continue": "Continue",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -46,7 +46,6 @@
   "common.editPermits.OrderReview.notification.info.orderSuccessMessage": "Parkeringstillståndet är elektroniskt och parkeringskontrollen identifierar ett giltigt ID baserat på ditt fordons registreringsnummer.",
   "common.editPermits.OrderReview.notification.info.orderSuccessTitle": "Prenumerationen lyckades",
   "common.editPermits.OrderReview.notification.info.pendingRefundTitle": "Retur väntar",
-  "common.editPermits.OrderReview.openConfirmPage": "Öppna bekräftelsemeddelande",
   "common.editPermits.OrderReview.title": "Ditt parkerings-ID",
   "common.editPermits.PriceChangePreview.actionBtn.cancel": "Avbryt",
   "common.editPermits.PriceChangePreview.actionBtn.continue": "Fortsätt",


### PR DESCRIPTION
## Description

At the moment, Talpa will handle all order confirmation dialogs after successful order.
Thus we do not need to implement own dialog for the same purpose separately for now.
Removed from the UI.

Fixes: [PV-473](https://helsinkisolutionoffice.atlassian.net/browse/PV-473)

## How Has This Been Tested?

Locally.

## Manual Testing Instructions for Reviewers

Test locally by creating order and observing the layout. Separate order confirmation dialog in our frontpage should no longer exist. 
