### PR TITLE
Update permit end localizations

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -72,7 +72,7 @@
   "common.endPermitDialog.EndPermitDialog.title": "End permit",
   "common.endPermitResult.EndPermitResult.actionBtn.confirmationMsg": "Open confirmation message",
   "common.endPermitResult.EndPermitResult.actionBtn.logout": "Log Out",
-  "common.endPermitResult.EndPermitResult.notification.first.message": "2 Permitss successfully terminated.",
+  "common.endPermitResult.EndPermitResult.notification.first.message": "Permit successfully ended.",
   "common.endPermitResult.EndPermitResult.notification.second.label": "Return pending",
   "common.footer.Footer.accessibility": "Accessibility",
   "common.footer.Footer.backToTop": "Back to top",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -81,7 +81,7 @@
   "common.endPermitDialog.EndPermitDialog.title": "Tunnuksen päättäminen",
   "common.endPermitResult.EndPermitResult.actionBtn.confirmationMsg": "Avaa vahvistusviesti",
   "common.endPermitResult.EndPermitResult.actionBtn.logout": "Kirjaudu ulos",
-  "common.endPermitResult.EndPermitResult.notification.first.message": "2 tunnuksen voimassaolo päätetty onnistuneesti.",
+  "common.endPermitResult.EndPermitResult.notification.first.message": "Tunnus päätetty onnistuneesti.",
   "common.endPermitResult.EndPermitResult.notification.second.label": "Palautus otettu käsittelyyn",
   "common.endPermitResult.EndPermitResult.notification.second.message": "Olemme lähettäneet vahvistusviestin sähköpostiisi {{email}}. Voit tarkistaa tiedot myös alta.",
   "common.footer.Footer.accessibility": "Saavutettavuus",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -71,7 +71,7 @@
   "common.endPermitDialog.EndPermitDialog.title": "Sluttillstånd",
   "common.endPermitResult.EndPermitResult.actionBtn.confirmationMsg": "Öppna bekräftelsemeddelande",
   "common.endPermitResult.EndPermitResult.actionBtn.logout": "Logga ut",
-  "common.endPermitResult.EndPermitResult.notification.first.message": "2 ID har avslutats.",
+  "common.endPermitResult.EndPermitResult.notification.first.message": "Tillståndet har avslutats.",
   "common.endPermitResult.EndPermitResult.notification.second.label": "Retur väntar",
   "common.endPermitResult.EndPermitResult.notification.second.message": "Vi har skickat ett bekräftelsemail till {{email}}. Du kan också kontrollera informationen nedan.",
   "common.footer.Footer.accessibility": "Tillgänglighet",


### PR DESCRIPTION
## Description

At the moment we show "2 permits ended" even if there are only one permit.
Update fi/sv/en-message locatizations for this.

## How Has This Been Tested?

Locally.

## Manual Testing Instructions for Reviewers

Test locally.
