### PR TITLE
PV-519: Add end time for open-ended permits

### DIFF
--- a/src/common/permit/Permit.tsx
+++ b/src/common/permit/Permit.tsx
@@ -124,10 +124,14 @@ const Permit = ({
               <span>
                 {format(new Date(permit.startTime as string), dateFormat)}
                 {' - '}
+                {permit.contractType === ParkingContractType.OPEN_ENDED
+                  ? format(
+                      new Date(permit.currentPeriodEndTime as string),
+                      dateFormat
+                    )
+                  : format(new Date(permit.endTime as string), dateFormat)}
                 {permit.contractType === ParkingContractType.OPEN_ENDED &&
-                  t(`${T_PATH}.contractType`)}
-                {permit.contractType !== ParkingContractType.OPEN_ENDED &&
-                  format(new Date(permit.endTime as string), dateFormat)}
+                  ' ' + t(`${T_PATH}.contractType`)}
               </span>
             </div>
           </>


### PR DESCRIPTION
## Description

Add end time for open-ended permits.

## Context

[PV-519](https://helsinkisolutionoffice.atlassian.net/browse/PV-519)

## How Has This Been Tested?

Manually.

## Manual Testing Instructions for Reviewers

Check that an open-ended permit shows the end of a 1-month period as the end time in the valid-permits view.

## Screenshots
![image](https://user-images.githubusercontent.com/2333857/212066456-e002bed1-2cbc-4213-8805-0ea063819eb3.png)
