### PR TITLE
Fix: Calculate refund months correctly

### DIFF
--- a/src/pages/changeVehicle/ChangeVehicle.tsx
+++ b/src/pages/changeVehicle/ChangeVehicle.tsx
@@ -107,7 +107,8 @@ const ChangeVehicle = (): React.ReactElement => {
               monthCount: getMonthCount(
                 new Date(),
                 permit.startTime as string,
-                product
+                product,
+                permit.endTime as string
               ),
             })),
         },

--- a/src/pages/endPermit/EndPermit.tsx
+++ b/src/pages/endPermit/EndPermit.tsx
@@ -53,7 +53,8 @@ const EndPermit = (): React.ReactElement => {
           monthCount: getMonthCount(
             endingOfPermitStartDate,
             permit.startTime as string,
-            product
+            product,
+            permit.endTime as string
           ),
         })),
     };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,7 +55,8 @@ export const dateAsNumber = (date: Date | string): number =>
 export const getMonthCount = (
   permitEndStartDate: Date,
   permitStartTime: string,
-  product: Product
+  product: Product,
+  permitEndTime: string
 ): number => {
   // It should consider the start time of the permit.
   // Eg: If permit was bought and started just before the permitEndStartDate
@@ -70,7 +71,8 @@ export const getMonthCount = (
 
   const intervalDuration = intervalToDuration({
     start: new Date(),
-    end: new Date(product.endDate),
+    end: new Date(permitEndTime),
   });
-  return intervalDuration.months || 0;
+  // eslint-disable-next-line no-magic-numbers
+  return (intervalDuration.years || 0) * 12 + (intervalDuration.months || 0);
 };


### PR DESCRIPTION
Calculate refund months correctly. Or at least presumably correctly.  Should use permit's end time, not product's.

## Description

Calculate refund months correctly... or at least presumably correctly.

## Context

Remaining month calculation was calculating the month count from the permit's start time to the *product's* end time. Changed to calculate it from the permit's start time to the *permit's* end time.

Also, intervalToDuration returns the duration in years, months, etc. and not in months. So the duration of 1.1.2000 - 1.2.2001, for example, would be 1 years and 1 months, not 13 months. The code assumed the latter; so in that scenario, it would return 1 month. We now account for the years as well.

## How Has This Been Tested?

Manually.

## Manual Testing Instructions for Reviewers

Create permits, try refunding. Go through the following cases:

- Active open-ended permits should refund for 0 months (0€).
- Future, not yet active open-ended permits should refund for 1 month
- Fixed period permits should refund for remaining months.
