### PR TITLE
Fix: Add a check for invalid permit times to fix huge refund sums

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,10 +69,15 @@ export const getMonthCount = (
     return product.quantity;
   }
 
+  if (!permitStartTime || !permitEndTime) {
+    return 0;
+  }
+
   const intervalDuration = intervalToDuration({
     start: new Date(),
     end: new Date(permitEndTime),
   });
+
   // eslint-disable-next-line no-magic-numbers
   return (intervalDuration.years || 0) * 12 + (intervalDuration.months || 0);
 };


### PR DESCRIPTION
## Description

Add a null check for permit start/end times.

## Context

If the permit didn't have an end time (like open-ended permits), it would calculate about 53 years worth of refunds. While hilarious, it doesn't exactly reflect the real refund amount.

## How Has This Been Tested?

Manually.

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/2333857/212328839-664c6769-b45d-4b1a-a2ce-06e82c699db2.png)

After:
![image](https://user-images.githubusercontent.com/2333857/212329059-d14b66b6-79b6-4861-8c0f-bf9c1e22e505.png)


