### PR TITLE
Add apartment support for addresses

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "jsxBracketSameLine": true,
+  "bracketSameLine": true,
   "singleQuote": true,
   "printWidth": 80,
   "arrowParens": "avoid"

--- a/src/common/address/Address.tsx
+++ b/src/common/address/Address.tsx
@@ -11,17 +11,23 @@ import { useTranslation } from 'react-i18next';
 import { PermitStateContext } from '../../hooks/permitProvider';
 import { Permit, UserAddress } from '../../types';
 import ParkingZonesMap from '../parkingZoneMap/ParkingZonesMap';
+import { formatAddress } from '../utils';
 import './address.scss';
 
 const T_PATH = 'common.address.Address';
 
 interface AddressHeaderProps {
   isPrimary: boolean;
-  addressLabel: string;
+  address: UserAddress;
+  addressApartment: string;
 }
 
-const AddressLabel: FC<AddressHeaderProps> = ({ isPrimary, addressLabel }) => {
-  const { t } = useTranslation();
+const AddressLabel: FC<AddressHeaderProps> = ({
+  isPrimary,
+  address,
+  addressApartment,
+}) => {
+  const { t, i18n } = useTranslation();
   return (
     <div className="address__headers">
       <span className="address__headers__sub_header">
@@ -29,7 +35,7 @@ const AddressLabel: FC<AddressHeaderProps> = ({ isPrimary, addressLabel }) => {
           ? t(`${T_PATH}.permanentAddress`)
           : t(`${T_PATH}.temporaryAddress`)}
       </span>
-      <span>{addressLabel}</span>
+      <span>{formatAddress(address, addressApartment, i18n.language)}</span>
     </div>
   );
 };
@@ -40,7 +46,7 @@ interface Props {
   address: UserAddress;
   selectedAddress: UserAddress | undefined;
   disableSelection?: boolean;
-  addressLabel: string;
+  addressApartment: string;
   setSelectedAddress?: (address: UserAddress) => void;
 }
 
@@ -50,7 +56,7 @@ const Address: FC<Props> = ({
   address,
   selectedAddress,
   disableSelection = false,
-  addressLabel,
+  addressApartment,
   setSelectedAddress,
 }): React.ReactElement => {
   const permitCtx = useContext(PermitStateContext);
@@ -80,7 +86,11 @@ const Address: FC<Props> = ({
             value={address.id}
             disabled={!address.zone || disableSelection}
             label={
-              <AddressLabel isPrimary={isPrimary} addressLabel={addressLabel} />
+              <AddressLabel
+                isPrimary={isPrimary}
+                address={address}
+                addressApartment={addressApartment}
+              />
             }
             checked={selectedAddress?.id === address.id}
             onClick={() =>
@@ -94,7 +104,11 @@ const Address: FC<Props> = ({
       )}
       {!showControl && (
         <div className="address">
-          <AddressLabel isPrimary={isPrimary} addressLabel={addressLabel} />
+          <AddressLabel
+            isPrimary={isPrimary}
+            address={address}
+            addressApartment={addressApartment}
+          />
         </div>
       )}
       <div className="zone_type">

--- a/src/common/addressLabel/AddressLabel.tsx
+++ b/src/common/addressLabel/AddressLabel.tsx
@@ -8,9 +8,13 @@ const T_PATH = 'common.addressLabel';
 
 interface AddressHeaderProps {
   address: UserAddress;
+  addressApartment: string;
 }
 
-const AddressLabel: FC<AddressHeaderProps> = ({ address: userAddress }) => {
+const AddressLabel: FC<AddressHeaderProps> = ({
+  address: userAddress,
+  addressApartment: apartment,
+}) => {
   const { t, i18n } = useTranslation();
   return (
     <div className="address-label-component">
@@ -22,7 +26,7 @@ const AddressLabel: FC<AddressHeaderProps> = ({ address: userAddress }) => {
               ? t(`${T_PATH}.permanentAddress`)
               : t(`${T_PATH}.temporaryAddress`)}
           </span>
-          <span>{formatAddress(userAddress, i18n.language)}</span>
+          <span>{formatAddress(userAddress, apartment, i18n.language)}</span>
         </div>
       </div>
     </div>

--- a/src/common/permit/Permit.tsx
+++ b/src/common/permit/Permit.tsx
@@ -50,7 +50,8 @@ const Permit = ({
   fetchPermits,
 }: Props): React.ReactElement => {
   const dateFormat = 'd.M.yyyy HH:mm';
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language;
   const navigate = useNavigate();
   const [editPermitId, setEditPermitId] = useState<string | null>(null);
   const [deleteTmpVehiclePermitId, setDeleteTmpVehiclePermitId] = useState<
@@ -174,7 +175,14 @@ const Permit = ({
               ? 'var(--color-black-10)'
               : 'var(--color-white)',
           }}>
-          <AddressLabel address={address} />
+          <AddressLabel
+            address={address}
+            addressApartment={
+              lang === 'sv'
+                ? permits[0].addressApartmentSv
+                : permits[0].addressApartment
+            }
+          />
           <ParkingZonesMap
             userAddress={address}
             zoom={13}

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,12 +1,16 @@
 import { extractIBAN } from 'ibantools';
 import { UserAddress, Vehicle } from '../types';
 
-export const formatAddress = (address: UserAddress, lang: string): string => {
+export const formatAddress = (
+  address: UserAddress,
+  addressApartment: string,
+  lang: string
+): string => {
   const { streetName, streetNameSv, city, citySv, postalCode, streetNumber } =
     address;
   const addressStreet = lang === 'sv' ? streetNameSv : streetName;
   const addressCity = lang === 'sv' ? citySv : city;
-  return `${addressStreet} ${streetNumber}, ${postalCode} ${addressCity}`;
+  return `${addressStreet} ${streetNumber} ${addressApartment}, ${postalCode} ${addressCity}`;
 };
 
 export function formatDateDisplay(datetime: string | Date): string {

--- a/src/graphql/createPermit.graphql
+++ b/src/graphql/createPermit.graphql
@@ -20,6 +20,8 @@ mutation Mutation($addressId: ID!, $registration: String!) {
     vehicleChanged
     zoneChanged
     isOrderConfirmed
+    addressApartment
+    addressApartmentSv
     activeTemporaryVehicle {
       id
       startTime

--- a/src/graphql/myProfileQuery.graphql
+++ b/src/graphql/myProfileQuery.graphql
@@ -8,7 +8,8 @@ query {
     email
     phoneNumber
     language
-    fullPrimaryAddress
+    primaryAddressApartment
+    primaryAddressApartmentSv
     primaryAddress {
       id
       streetName
@@ -27,7 +28,8 @@ query {
         location
       }
     }
-    fullOtherAddress
+    otherAddressApartment
+    otherAddressApartmentSv
     otherAddress {
       id
       streetName

--- a/src/graphql/permits.graphql
+++ b/src/graphql/permits.graphql
@@ -20,6 +20,8 @@ query Query {
     vehicleChanged
     zoneChanged
     isOrderConfirmed
+    addressApartment
+    addressApartmentSv
     activeTemporaryVehicle {
       id
       startTime

--- a/src/graphql/updatePermit.graphql
+++ b/src/graphql/updatePermit.graphql
@@ -19,6 +19,8 @@ mutation Mutation($input: ParkingPermitInput!, $permitId: ID) {
     vehicleChanged
     zoneChanged
     isOrderConfirmed
+    addressApartment
+    addressApartmentSv
     activeTemporaryVehicle {
       id
       startTime

--- a/src/pages/addressSelector/AddressSelector.tsx
+++ b/src/pages/addressSelector/AddressSelector.tsx
@@ -14,7 +14,8 @@ import './addressSelector.scss';
 const T_PATH = 'pages.addressSelector.AddressSelector';
 
 const AddressSelector = (): React.ReactElement => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language;
   const navigate = useNavigate();
   const profileCtx = useContext(UserProfileContext);
   const permitCtx = useContext(PermitStateContext);
@@ -78,7 +79,11 @@ const AddressSelector = (): React.ReactElement => {
                 disableSelection={!!validRegistrationNumbers?.length}
                 address={primaryAddress}
                 selectedAddress={selectedAddress}
-                addressLabel={profile.fullPrimaryAddress}
+                addressApartment={
+                  lang === 'sv'
+                    ? profile.primaryAddressApartmentSv
+                    : profile.primaryAddressApartment
+                }
               />
             )}
 
@@ -89,7 +94,11 @@ const AddressSelector = (): React.ReactElement => {
                 address={otherAddress}
                 disableSelection={!!validRegistrationNumbers?.length}
                 selectedAddress={selectedAddress}
-                addressLabel={profile.fullOtherAddress}
+                addressApartment={
+                  lang === 'sv'
+                    ? profile.otherAddressApartmentSv
+                    : profile.otherAddressApartment
+                }
               />
             )}
           </div>

--- a/src/pages/changeAddress/ChangeAddress.tsx
+++ b/src/pages/changeAddress/ChangeAddress.tsx
@@ -25,7 +25,8 @@ enum ChangeAddressStep {
 const T_PATH = 'pages.changeAddress.ChangeAddress';
 
 const ChangeAddress = (): React.ReactElement => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language;
   const navigate = useNavigate();
   const [step, setStep] = useState<ChangeAddressStep>(
     ChangeAddressStep.ADDRESS
@@ -50,19 +51,20 @@ const ChangeAddress = (): React.ReactElement => {
     return <Navigate to={ROUTES.BASE} />;
   }
 
-  const { primaryAddress, otherAddress } = profile;
+  const {
+    primaryAddress,
+    otherAddress,
+    primaryAddressApartment,
+    primaryAddressApartmentSv,
+    otherAddressApartment,
+    otherAddressApartmentSv,
+  } = profile;
   const primaryAddressZoneId = primaryAddress.zone?.id;
   const otherAddressZoneId = otherAddress.zone?.id;
 
   // Cannot update address if there's no other address
   // or the zone information is unavailable from address
-  // or the two address are in the same zone
-  if (
-    !otherAddress ||
-    !primaryAddressZoneId ||
-    !otherAddressZoneId ||
-    primaryAddressZoneId === otherAddressZoneId
-  ) {
+  if (!otherAddress || !primaryAddressZoneId || !otherAddressZoneId) {
     return (
       <div className="change-address-component">
         <Notification type="info">
@@ -87,6 +89,15 @@ const ChangeAddress = (): React.ReactElement => {
 
   if (!selectedAddress && notUsedAddress) {
     setSelectedAddress(notUsedAddress);
+  }
+
+  let addressApartment = '';
+  if (selectedAddress === primaryAddress) {
+    addressApartment =
+      lang === 'sv' ? primaryAddressApartmentSv : primaryAddressApartment;
+  } else {
+    addressApartment =
+      lang === 'sv' ? otherAddressApartmentSv : otherAddressApartment;
   }
 
   const priceChangeTotal = priceChangesList.reduce(
@@ -116,7 +127,7 @@ const ChangeAddress = (): React.ReactElement => {
                 showControl={selectableAddresses.length > 1}
                 selectedAddress={selectedAddress}
                 setSelectedAddress={setSelectedAddress}
-                addressLabel=""
+                addressApartment={addressApartment}
               />
             ))}
           </div>

--- a/src/types/permits.ts
+++ b/src/types/permits.ts
@@ -46,6 +46,8 @@ export type Permit = {
   vehicleChanged: boolean;
   zoneChanged: boolean;
   isOrderConfirmed: boolean;
+  addressApartment: string;
+  addressApartmentSv: string;
 };
 
 export type Vehicle = {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -31,8 +31,10 @@ export type UserProfile = {
   language: string;
   phoneNumber: string;
   primaryAddress: UserAddress;
-  fullPrimaryAddress: string;
+  primaryAddressApartment: string;
+  primaryAddressApartmentSv: string;
   otherAddress: UserAddress;
-  fullOtherAddress: string;
+  otherAddressApartment: string;
+  otherAddressApartmentSv: string;
   token: string;
 };


### PR DESCRIPTION
## Description

Add apartment support for addresses.

## Context

[PV-591](https://helsinkisolutionoffice.atlassian.net/browse/PV-591)

## How Has This Been Tested?

Manually through the normal permit buying process.

## Manual Testing Instructions for Reviewers

Login to webshop and observe that the user has apartment details as part of their address whenever necessary.

## Screenshots

![webshop-permit-address-with-apartment](https://github.com/City-of-Helsinki/parking-permits-ui/assets/2784933/48b38db9-9921-4106-a30b-7c38da4dfd8f)



[PV-591]: https://helsinkisolutionoffice.atlassian.net/browse/PV-591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ