### PR TITLE
Show meaningful error messages

### DIFF
--- a/src/common/editPermits/VehicleDetails.tsx
+++ b/src/common/editPermits/VehicleDetails.tsx
@@ -22,7 +22,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { getVehicleInformation } from '../../graphql/permitGqlClient';
 import { PermitStateContext } from '../../hooks/permitProvider';
 import { Permit, ROUTES, Vehicle } from '../../types';
-import { formatDate, formatMonthlyPrice } from '../../utils';
+import { formatDate, formatErrors, formatMonthlyPrice } from '../../utils';
 import './vehicleDetails.scss';
 import DiscountLabel from '../discountLabel/DiscountLabel';
 
@@ -68,9 +68,7 @@ const VehicleDetails: FC<Props> = ({
     setError('');
     await getVehicleInformation(tempRegistration)
       .then(setVehicle)
-      .catch(errors =>
-        setError(errors?.map((e: { message: string }) => e?.message).join('\n'))
-      );
+      .catch(errors => setError(formatErrors(errors)));
     setLoading(false);
   }, [setVehicle, tempRegistration]);
 

--- a/src/hooks/permitHook.ts
+++ b/src/hooks/permitHook.ts
@@ -18,7 +18,7 @@ import {
   UserAddress,
   Zone,
 } from '../types';
-import { getEnv } from '../utils';
+import { getEnv, formatErrors } from '../utils';
 import { UserProfileContext } from './userProfileProvider';
 
 const usePermitState = (): PermitActions => {
@@ -35,15 +35,7 @@ const usePermitState = (): PermitActions => {
 
   const onError = (errors: ParkingPermitError[] | string | string[]) => {
     setStatus('error');
-    if (!errors) {
-      return setError('Some thing went wrong');
-    }
-    if (typeof errors === 'string') {
-      return setError(errors);
-    }
-    return setError(
-      errors?.map(e => (typeof e !== 'string' && e?.message) || e).join('\n')
-    );
+    setError(formatErrors(errors));
   };
 
   const fetchPermits = useCallback(async () => {

--- a/src/hooks/userProfileHook.ts
+++ b/src/hooks/userProfileHook.ts
@@ -11,6 +11,7 @@ import {
   UpdateLanguageResult,
   UserProfile,
 } from '../types';
+import { formatErrors } from '../utils';
 import { ApiAccessTokenContext } from './apiAccessTokenProvider';
 import { getGqlClient } from './utils';
 
@@ -46,7 +47,7 @@ const useProfile = (): ProfileActions => {
         });
       if (result.errors) {
         setStatus('error');
-        setError(result.errors.map(err => err.message).join('\n'));
+        setError(formatErrors(result.errors));
       } else {
         setError(undefined);
         const { profile: userProfile } = result.data;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -27,6 +27,7 @@
   "common.deleteTemporaryVehicleDialog.DeleteTemporaryVehicleDialog.title": "Delete temporary vehicle",
   "common.discountLabel.DiscountLabel.discount": "I would also like to receive a 50 % discount on other off-street parking when paying with parking apps.",
   "common.discountLabel.DiscountLabel.readMore": "Read more.",
+  "common.genericError": "Something went wrong. Try again later.",
   "common.editPermitDialog.EditPermitDialog.actionBtn.cancel": "Cancel",
   "common.editPermitDialog.EditPermitDialog.actionBtn.continue": "Continue",
   "common.editPermitDialog.EditPermitDialog.newVehicle": "Change the token's vehicle permanently. The change may affect the price of the token.",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -20,6 +20,7 @@
   "common.address.Address.temporaryAddress": "Tilapäinen osoite",
   "common.addressLabel.permanentAddress": "Pysyvä osoite",
   "common.addressLabel.temporaryAddress": "Tilapäinen osoite",
+  "common.genericError": "Jokin meni pieleen. Kokeile hetken kuluttua uudelleen.",
   "common.deleteTemporaryVehicleDialog.DeleteTemporaryVehicleDialog.actionBtn.cancel": "Peruuta",
   "common.deleteTemporaryVehicleDialog.DeleteTemporaryVehicleDialog.actionBtn.continue": "Jatka",
   "common.deleteTemporaryVehicleDialog.DeleteTemporaryVehicleDialog.message": "Alkuperäisen ajoneuvon tiedot palautetaan tunnuksen tietoihin.",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -20,6 +20,7 @@
   "common.address.Address.temporaryAddress": "Tillfällig adress",
   "common.addressLabel.permanentAddress": "Permanent adress",
   "common.addressLabel.temporaryAddress": "Tillfällig adress",
+  "common.genericError": "Något gick fel. Försök igen senare.",
   "common.deleteTemporaryVehicleDialog.DeleteTemporaryVehicleDialog.actionBtn.cancel": "Avbryt",
   "common.deleteTemporaryVehicleDialog.DeleteTemporaryVehicleDialog.actionBtn.continue": "Fortsätt",
   "common.deleteTemporaryVehicleDialog.DeleteTemporaryVehicleDialog.message": "Original fordonsdata kommer att returneras till ID-data.",

--- a/src/pages/temporaryVehicle/TemporaryVehicle.tsx
+++ b/src/pages/temporaryVehicle/TemporaryVehicle.tsx
@@ -19,7 +19,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { addTemporaryVehicleToPermit } from '../../graphql/permitGqlClient';
 import { PermitStateContext } from '../../hooks/permitProvider';
 import { ROUTES } from '../../types';
-import { combineDateAndTime, validateTime } from '../../utils';
+import { combineDateAndTime, formatErrors, validateTime } from '../../utils';
 import './temporaryVehicle.scss';
 
 const T_PATH = 'pages.temporaryVehicle.TemporaryVehicle';
@@ -63,7 +63,7 @@ const TemporaryVehicle = (): React.ReactElement => {
         navigate(ROUTES.VALID_PERMITS);
       })
       .catch(err => {
-        setError(err?.map((e: { message: string }) => e.message)?.join());
+        setError(formatErrors(err));
       });
     setLoading(false);
   };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,30 @@
+import { GraphQLError } from 'graphql';
 import { format, intervalToDuration } from 'date-fns';
-import { ParkingContractType, Permit, Product } from './types';
+import {
+  ParkingContractType,
+  ParkingPermitError,
+  Permit,
+  Product,
+} from './types';
+
+export const formatErrors = (
+  errors: ParkingPermitError[] | readonly GraphQLError[] | string[] | string,
+  defaultError = 'common.genericError'
+): string => {
+  // normalizes errors into single string.
+  if (!errors) {
+    return defaultError;
+  }
+  if (typeof errors === 'string') {
+    return errors;
+  }
+  if (typeof errors?.map === 'function') {
+    return errors
+      .map(e => (typeof e !== 'string' && e?.message) || e || defaultError)
+      .join('\n');
+  }
+  return defaultError;
+};
 
 export const validateTime = (time: string): boolean =>
   /^([0-1]?[0-9]|2[0-4]):([0-5][0-9])(:[0-5][0-9])?$/.test(time);


### PR DESCRIPTION
This change should handle different API-related error messages, so that the user is always presented with a message in case of failure. This includes a default message should the API not return a valid errors object.

## Description

A single error message handler function has been added, so that we handle errors consistently throughout the application. This function should be able to handle for example GraphQL errors and simple strings, and should return a default message if the error format does not resolve to a meaningful error. 

## Context

[PV-615](https://helsinkisolutionoffice.atlassian.net/browse/PV-615)

## How Has This Been Tested?

Tested manually by triggering server-side errors when creating and retrieving parking permits.

## Manual Testing Instructions for Reviewers

See above

## Screenshots

![Screenshot from 2023-09-04 09-42-16](https://github.com/City-of-Helsinki/parking-permits-ui/assets/131681805/160fba9c-53ae-4f0f-84f2-fc7e9140f77d)



[PV-615]: https://helsinkisolutionoffice.atlassian.net/browse/PV-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ