### PR TITLE
Use permit start and end dates in period prices

### DIFF
--- a/src/pages/durationSelector/DurationSelector.tsx
+++ b/src/pages/durationSelector/DurationSelector.tsx
@@ -28,7 +28,12 @@ import {
   ROUTES,
   STEPPER,
 } from '../../types';
-import { formatDate, formatMonthlyPrice, formatPrice } from '../../utils';
+import {
+  formatPermitStartDate,
+  formatPermitEndDate,
+  formatMonthlyPrice,
+  formatPrice,
+} from '../../utils';
 import './durationSelector.scss';
 
 const MAX_MONTH = 12;
@@ -89,14 +94,15 @@ const DurationSelector = (): React.ReactElement => {
   const getPrices = (permit: PermitModel) => {
     const { contractType, products } = permit;
     const isOpenEnded = contractType === ParkingContractType.OPEN_ENDED;
-
     return (
       <div className="prices">
         {products.map(product => (
           <div key={uuidv4()} className="price">
-            <div>{`(${formatDate(product.startDate)} - ${formatDate(
-              product.endDate
-            )})`}</div>
+            <div>{`(${formatPermitStartDate(
+              products,
+              product,
+              permit
+            )} - ${formatPermitEndDate(products, product, permit)})`}</div>
             <div style={{ marginRight: '4px' }}>
               {t('pages.durationSelector.DurationSelector.total')}
             </div>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,6 +72,30 @@ export const formatMonthlyPrice = (
   t: TranslateFunction
 ): string => `${formatPrice(price)} ${t('common.pricePerMonth')}`;
 
+export const formatPermitStartDate = (
+  products: Product[],
+  product: Product,
+  permit: Permit
+): string => {
+  let date = product.startDate;
+  if (product === products.at(0)) {
+    date = permit.startTime as string;
+  }
+  return formatDate(date);
+};
+
+export const formatPermitEndDate = (
+  products: Product[],
+  product: Product,
+  permit: Permit
+): string => {
+  let date = product.endDate;
+  if (product === products.at(-1)) {
+    date = permit.endTime as string;
+  }
+  return formatDate(date);
+};
+
 export const isOpenEndedPermitStarted = (
   permits: Permit[]
 ): Permit | undefined =>


### PR DESCRIPTION
## Description

In permit duration selection, use permit start date as first period price start date and permit end date as last period price end date.

## Context

[PV-636](https://helsinkisolutionoffice.atlassian.net/browse/PV-636)

## How Has This Been Tested?

Manually by configuring different product price ranges and testing the UI calculation logic.

## Manual Testing Instructions for Reviewers

Configure different product price ranges and test that the dates work as expected.

## Screenshots
<img width="1128" alt="permit prices" src="https://github.com/City-of-Helsinki/parking-permits-ui/assets/2784933/17fe4147-df15-496b-943c-83062973851d">




[PV-636]: https://helsinkisolutionoffice.atlassian.net/browse/PV-636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ