### PR TITLE
Use permit start and end dates in vehicle details card

### DIFF
--- a/src/common/editPermits/VehicleDetails.tsx
+++ b/src/common/editPermits/VehicleDetails.tsx
@@ -22,7 +22,12 @@ import { v4 as uuidv4 } from 'uuid';
 import { getVehicleInformation } from '../../graphql/permitGqlClient';
 import { PermitStateContext } from '../../hooks/permitProvider';
 import { Permit, ROUTES, Vehicle } from '../../types';
-import { formatDate, formatErrors, formatMonthlyPrice } from '../../utils';
+import {
+  formatPermitStartDate,
+  formatPermitEndDate,
+  formatErrors,
+  formatMonthlyPrice,
+} from '../../utils';
 import './vehicleDetails.scss';
 import DiscountLabel from '../discountLabel/DiscountLabel';
 
@@ -130,8 +135,14 @@ const VehicleDetails: FC<Props> = ({
                         t
                       )}
                     </div>
-                    <div>{`(${formatDate(product.startDate)} - ${formatDate(
-                      product.endDate
+                    <div>{`(${formatPermitStartDate(
+                      permit.products,
+                      product,
+                      permit
+                    )} - ${formatPermitEndDate(
+                      permit.products,
+                      product,
+                      permit
                     )})`}</div>
                   </div>
                 ))}


### PR DESCRIPTION
## Description

In permit vehicle details card, use permit start date as first period price start date and permit end date as last period price end date.

## Context

[PV-646](https://helsinkisolutionoffice.atlassian.net/browse/PV-646)

## How Has This Been Tested?

Manually using "change vehicle"-feature.
"Change address"-feature does not have the vehicle details view at all at this moment.

## Manual Testing Instructions for Reviewers

Test with "change vehicle"-feature. Observe vehicle details card prices to change according to permit start and end time.

## Screenshots

<img width="638" alt="change vehicle permit dates" src="https://github.com/City-of-Helsinki/parking-permits-ui/assets/2784933/76b0c7a5-760b-4258-ac3e-9df4e800a218">
<img width="1148" alt="change vehicle permit dates high to low emission" src="https://github.com/City-of-Helsinki/parking-permits-ui/assets/2784933/ae3acea4-8007-401a-b9e7-db3883e36da6">



[PV-646]: https://helsinkisolutionoffice.atlassian.net/browse/PV-646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ