### PR TITLE
Duration selector: refactor translation calls

### DIFF
--- a/src/common/purchaseNotification/PurchaseNotification.tsx
+++ b/src/common/purchaseNotification/PurchaseNotification.tsx
@@ -3,13 +3,13 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Permit, PermitStatus } from '../../types';
 
-const T_PATH = 'common.PurchaseNotification';
+const T_PATH = 'common.PurchaseNotification.notification';
 
 export interface Props {
   validPermits: Permit[];
 }
 const PurchaseNotification = ({ validPermits }: Props): React.ReactElement => {
-  const { t } = useTranslation();
+  const { t } = useTranslation('translation', { keyPrefix: T_PATH });
   const checkoutUrls = Array.from(
     new Set(
       validPermits
@@ -31,31 +31,32 @@ const PurchaseNotification = ({ validPermits }: Props): React.ReactElement => {
     const uniqueOrderIds = Array.from(new Set(orderIds));
     const isSecondary = uniqueOrderIds.length > 1;
     const isPayment = checkoutUrls.length > 0;
-    const isAlertType = validPermits.some(
+    const isAlert = validPermits.some(
       permit =>
         permit.status === PermitStatus.DRAFT ||
         permit.status === PermitStatus.PAYMENT_IN_PROGRESS
     );
-    if (isAlertType) {
-      let translationPath = `${T_PATH}.notification.alert`;
+
+    let keyPrefix: string;
+
+    if (isAlert) {
+      keyPrefix = 'alert';
+
+      if (isSecondary) {
+        keyPrefix += '-2';
+      }
 
       if (isPayment) {
-        translationPath += '.payment';
+        keyPrefix += '.payment';
       }
-      if (isSecondary) {
-        translationPath += '-2';
-      }
-
-      return {
-        type: 'alert',
-        label: t(`${translationPath}.label`),
-        message: t(`${translationPath}.message`),
-      };
+    } else {
+      keyPrefix = 'success';
     }
+
     return {
-      type: 'success',
-      label: t(`${T_PATH}.notification.success.label`),
-      message: t(`${T_PATH}.notification.success.message`),
+      type: isAlert ? 'alert' : 'success',
+      label: t(`${keyPrefix}.label`),
+      message: t(`${keyPrefix}.message`),
     };
   };
 
@@ -83,7 +84,7 @@ const PurchaseNotification = ({ validPermits }: Props): React.ReactElement => {
               display: 'inline-flex',
               alignItems: 'center',
             }}>
-            {t(`${T_PATH}.notification.completeOrder`)}
+            {t('completeOrder')}
             <IconLinkExternal style={{ marginLeft: 'var(--spacing-xs)' }} />
           </a>
         </div>

--- a/src/pages/durationSelector/DurationSelector.tsx
+++ b/src/pages/durationSelector/DurationSelector.tsx
@@ -40,7 +40,8 @@ const MAX_MONTH = 12;
 const T_PATH = 'pages.durationSelector.DurationSelector';
 
 const DurationSelector = (): React.ReactElement => {
-  const { t } = useTranslation();
+  const { t: gt } = useTranslation();
+  const { t } = useTranslation('translation', { keyPrefix: T_PATH });
   const permitCtx = useContext(PermitStateContext);
   const navigate = useNavigate();
   const [orderRequest, setOrderRequest] = useState<boolean>(false);
@@ -103,12 +104,10 @@ const DurationSelector = (): React.ReactElement => {
               product,
               permit
             )} - ${formatPermitEndDate(products, product, permit)})`}</div>
-            <div style={{ marginRight: '4px' }}>
-              {t('pages.durationSelector.DurationSelector.total')}
-            </div>
+            <div style={{ marginRight: '4px' }}>{t('total')}</div>
             <div className="offer">
               {isOpenEnded
-                ? formatMonthlyPrice(product.unitPrice, t)
+                ? formatMonthlyPrice(product.unitPrice, gt)
                 : `${formatPrice(product.totalPrice)} €`}
             </div>
           </div>
@@ -144,23 +143,18 @@ const DurationSelector = (): React.ReactElement => {
     <div className="duration-selector-component">
       <div className="zone__type">
         <div className="zone__type__symbol">{address.zone?.name}</div>
-        <div className="zone__type__label">
-          {t(`${T_PATH}.residentParkingZone`)}
-        </div>
+        <div className="zone__type__label">{t('residentParkingZone')}</div>
       </div>
       {!!validPermits?.length && (
         <>
           <div className="section-label">
-            {t(`${T_PATH}.validPermitCount`, { count: validPermits.length })}
+            {t('validPermitCount', { count: validPermits.length })}
           </div>
           <Permit permits={validPermits} address={address} hideMap />
         </>
       )}
       <div className="section-label">
-        {t(`
-          ${T_PATH}.${
-          validPermits?.length ? 'secondPermitLabel' : 'sectionLabel'
-        }`)}
+        {t(validPermits?.length ? 'secondPermitLabel' : 'sectionLabel')}
       </div>
       {permitCtx?.getStatus() === 'error' && (
         <Notification type="error">
@@ -181,7 +175,7 @@ const DurationSelector = (): React.ReactElement => {
               <div className="car-info">
                 {draftPermits.length > 1 && (
                   <div className="permit-count">
-                    {t(`${T_PATH}.permitCount`, { count: index + 1 })}
+                    {t('permitCount', { count: index + 1 })}
                   </div>
                 )}
                 <div className="car-details">{getCarDetails(permit)}</div>
@@ -190,14 +184,14 @@ const DurationSelector = (): React.ReactElement => {
             </div>
             {mainPermitToUpdate.contractType ===
               ParkingContractType.OPEN_ENDED && (
-              <div>{t(`${T_PATH}.openEndedAssistiveText`)}</div>
+              <div>{t('openEndedAssistiveText')}</div>
             )}
 
             {mainPermitToUpdate.contractType ===
               ParkingContractType.FIXED_PERIOD && (
               <div className="time-period with-bottom-border">
                 <div className={classNames(`assistive-text`)}>
-                  {t(`${T_PATH}.fixedPeriodAssistiveText`, {
+                  {t('fixedPeriodAssistiveText', {
                     max: getMaxMonth(permit),
                   })}
                 </div>
@@ -205,7 +199,7 @@ const DurationSelector = (): React.ReactElement => {
                   style={{ maxWidth: '250px' }}
                   className="month-selection"
                   id={uuidv4()}
-                  helperText={t(`${T_PATH}.monthSelectionHelpText`, {
+                  helperText={t('monthSelectionHelpText', {
                     max: getMaxMonth(permit),
                   })}
                   label=""
@@ -228,7 +222,7 @@ const DurationSelector = (): React.ReactElement => {
             )}
           </Card>
           <div className="price-info hide-in-desktop">
-            <div>{t(`${T_PATH}.permitPrice`)}</div>
+            <div>{t('permitPrice')}</div>
             {getPrices(permit)}
           </div>
         </div>
@@ -242,7 +236,7 @@ const DurationSelector = (): React.ReactElement => {
           {orderRequest && <LoadingSpinner small />}
           {!orderRequest && (
             <>
-              <span>{t(`${T_PATH}.actionBtn.continue`)}</span>
+              <span>{t('actionBtn.continue')}</span>
               <IconArrowRight />
             </>
           )}
@@ -254,7 +248,7 @@ const DurationSelector = (): React.ReactElement => {
           variant="secondary"
           iconLeft={<IconArrowLeft />}
           onClick={() => navigate(ROUTES.PERMIT_PRICES)}>
-          <span>{t(`${T_PATH}.actionBtn.selectRegistration`)}</span>
+          <span>{t('actionBtn.selectRegistration')}</span>
         </Button>
       </div>
     </div>


### PR DESCRIPTION
This uses the "keyPrefix" argument when initializing useTranslation() hook:

https://react.i18next.com/latest/usetranslation-hook#optional-keyprefix-option

This makes calls to t() less error-prone than concatenating T_PATH strings in each call.

## Context

[PV-654](https://helsinkisolutionoffice.atlassian.net/browse/PV-654)

## How Has This Been Tested?

Tested manually: create a new permit for a customer and navigate to duration selector step.

## Manual Testing Instructions for Reviewers

See above

## Screenshots

![Screenshot from 2023-10-17 09-12-24](https://github.com/City-of-Helsinki/parking-permits-ui/assets/131681805/04c3e1cf-22aa-43e5-b548-45df434f326b)


[PV-654]: https://helsinkisolutionoffice.atlassian.net/browse/PV-654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ