### PR TITLE
Use session storage as OIDC-storage

### DIFF
--- a/src/client/oidc-react.ts
+++ b/src/client/oidc-react.ts
@@ -77,7 +77,7 @@ export function createOidcClient(): Client {
   }
   const clientConfig = getClientConfig();
   const oidcConfig: UserManagerSettings = {
-    userStore: new WebStorageStateStore({ store: window.localStorage }),
+    userStore: new WebStorageStateStore({ store: window.sessionStorage }),
     authority: clientConfig.authority,
     automaticSilentRenew: clientConfig.automaticSilentRenew,
     client_id: clientConfig.clientId,


### PR DESCRIPTION
## Description

Use sessionStorage as OIDC-storage as it is considered safer than localStorage and because Talpa is also using that, potentially making the Talpa-integration user-interactions smoother.

## Context

[PV-619](https://helsinkisolutionoffice.atlassian.net/browse/PV-619)

## How Has This Been Tested?

Manually, observe that browser's localStorage is used instead of sessionStorage.

## Manual Testing Instructions for Reviewers

Test that the application user login/logout and Talpa-integration is still working as previously.



[PV-619]: https://helsinkisolutionoffice.atlassian.net/browse/PV-619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ