### PR TITLE
Hide add secondary vehicle button for open ended permit

### DIFF
--- a/src/pages/validPermits/ValidPermits.tsx
+++ b/src/pages/validPermits/ValidPermits.tsx
@@ -11,6 +11,7 @@ import PurchaseNotification from '../../common/purchaseNotification/PurchaseNoti
 import { PermitStateContext } from '../../hooks/permitProvider';
 import { UserProfileContext } from '../../hooks/userProfileProvider';
 import {
+  ParkingContractType,
   Permit as PermitModel,
   PermitEndType,
   PermitStatus,
@@ -58,6 +59,8 @@ const ValidPermits = (): React.ReactElement => {
   const hasAddressChanged = (permit: PermitModel) => permit.zoneChanged;
   const hasTemporaryVehicle = (permit: PermitModel) =>
     !!permit.activeTemporaryVehicle;
+  const isOpenEndedPermit = (permit: PermitModel) =>
+    permit.contractType === ParkingContractType.OPEN_ENDED;
 
   const canEndAfterCurrentPeriod =
     first(validPermits)?.canEndAfterCurrentPeriod ?? false;
@@ -141,7 +144,7 @@ const ValidPermits = (): React.ReactElement => {
         />
       )}
       <div className="action-buttons">
-        {validPermits.length === 1 && (
+        {validPermits.length === 1 && !validPermits.some(isOpenEndedPermit) && (
           <Button
             className="action-btn"
             variant="secondary"


### PR DESCRIPTION
## Description

Hide add secondary vehicle button for open ended permit.

## Context

[PV-673](https://helsinkisolutionoffice.atlassian.net/browse/PV-673)

## How Has This Been Tested?

Manually.

## Screenshots
<img width="1081" alt="open ended no add second vehicle button" src="https://github.com/City-of-Helsinki/parking-permits-ui/assets/2784933/6977a7a9-dfb0-4a88-8ab0-79d0827b5b17">




[PV-673]: https://helsinkisolutionoffice.atlassian.net/browse/PV-673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ