### PR TITLE
Calculate unit price per vehicle based on product unit price and low

### DIFF
--- a/src/common/editPermits/VehicleDetails.tsx
+++ b/src/common/editPermits/VehicleDetails.tsx
@@ -28,6 +28,7 @@ import {
   formatMonthlyPrice,
   getPermitStartDate,
   getPermitEndDate,
+  calcProductUnitPrice,
 } from '../../utils';
 import './vehicleDetails.scss';
 import DiscountLabel from '../discountLabel/DiscountLabel';
@@ -38,7 +39,6 @@ interface Props {
   permit: Permit;
   vehicle: Vehicle | undefined;
   onContinue: () => void;
-  priceChangeMultiplier: number;
   setVehicle: Dispatch<SetStateAction<Vehicle | undefined>>;
   lowEmissionChecked: boolean;
   setLowEmissionChecked: Dispatch<SetStateAction<boolean>>;
@@ -49,7 +49,6 @@ const VehicleDetails: FC<Props> = ({
   vehicle,
   setVehicle,
   onContinue,
-  priceChangeMultiplier,
   lowEmissionChecked,
   setLowEmissionChecked,
 }): React.ReactElement => {
@@ -132,7 +131,7 @@ const VehicleDetails: FC<Props> = ({
                   <div key={uuidv4()} className="price">
                     <div className="offer">
                       {formatMonthlyPrice(
-                        product.unitPrice * priceChangeMultiplier,
+                        calcProductUnitPrice(product, vehicle.isLowEmission),
                         t
                       )}
                     </div>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -114,6 +114,28 @@ export const isOpenEndedPermitStarted = (
 export const dateAsNumber = (date: MaybeDate): number =>
   normalizeDateValue(date).valueOf();
 
+export const calcProductUnitPrice = (
+  product: Product,
+  isLowEmission?: boolean,
+  isVat?: boolean
+): number => {
+  // returns modified unit price if low-emission vehicle, otherwise returns full price
+  const { unitPrice, lowEmissionDiscount, vat } = product;
+
+  const basePrice = isVat ? unitPrice * vat : unitPrice;
+
+  if (isLowEmission && lowEmissionDiscount) {
+    return basePrice - basePrice * lowEmissionDiscount;
+  }
+
+  return basePrice;
+};
+
+export const calcProductUnitVatPrice = (
+  product: Product,
+  isLowEmission?: boolean
+): number => calcProductUnitPrice(product, isLowEmission, true);
+
 export const getPermitStartDate = (
   product: Product,
   permit: Permit


### PR DESCRIPTION
## Description

Calculates vehicle price changes based on the product low emission discount, rather than calculating the multiplier separately.

## Context

[PV-701](https://helsinkisolutionoffice.atlassian.net/browse/PV-701)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

1. Create high emission permit, switch to low emission vehicle
2. Create low emission permit, switch to high emission vehicle
3. Create high emission permit, switch to another high emission vehicle 

All test cases were for fixed term (3 month) permits.

For these use cases I had the following products:

1st June -> 30th november 45.00 pcm (low emission discount 33.3300%)
1st december -> 60.00 pcm (low emission discount 25%)

## Screenshots

![Screenshot from 2023-11-14 12-43-12](https://github.com/City-of-Helsinki/parking-permits-ui/assets/131681805/0b09368a-a484-4e5a-bfb6-5a1f38d48e5f)


[PV-701]: https://helsinkisolutionoffice.atlassian.net/browse/PV-701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ