### PR TITLE
Show positive values in IBAN refund form

### DIFF
--- a/src/common/editPermits/PriceChangePreview.tsx
+++ b/src/common/editPermits/PriceChangePreview.tsx
@@ -168,12 +168,15 @@ const PriceChangePreview: React.FC<PriceChangePreviewProps> = ({
                 </b>
               </div>
             </div>
-            {!isRefund && (
-              <div className="row">
-                <div>{t(`${T_PATH}.refundTotalVat`)}</div>
-                <div>{formatPrice(priceChangeVatTotal)} &euro;</div>
+            <div className="row">
+              <div>{t(`${T_PATH}.refundTotalVat`)}</div>
+              <div>
+                {formatPrice(
+                  isRefund ? Math.abs(priceChangeVatTotal) : priceChangeVatTotal
+                )}{' '}
+                &euro;
               </div>
-            )}
+            </div>
           </div>
         )}
       </div>

--- a/src/common/editPermits/Refund.tsx
+++ b/src/common/editPermits/Refund.tsx
@@ -9,6 +9,7 @@ import {
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { isValidIBAN } from '../utils';
+import { formatPrice } from '../../utils';
 import './Refund.scss';
 
 const T_PATH = 'common.editPermits.Refund';
@@ -42,11 +43,11 @@ const Refund: React.FC<RefundProps> = ({
       <div className="refund-info">
         <div className="row">
           <div>{t(`${T_PATH}.refundTotal`)}</div>
-          <div>{parseFloat(refundTotal.toFixed(2))} €</div>
+          <div>{formatPrice(Math.abs(refundTotal))} €</div>
         </div>
         <div className="row">
           <div>{t(`${T_PATH}.refundTotalVat`)}</div>
-          <div>{parseFloat(refundTotalVat.toFixed(2))} €</div>
+          <div>{formatPrice(Math.abs(refundTotalVat))} €</div>
         </div>
       </div>
       <div className="refund-description">

--- a/src/pages/changeVehicle/ChangeVehicle.tsx
+++ b/src/pages/changeVehicle/ChangeVehicle.tsx
@@ -158,8 +158,8 @@ const ChangeVehicle = (): React.ReactElement => {
       )}
       {step === ChangeVehicleStep.REFUND && (
         <Refund
-          refundTotal={-getChangeTotal(priceChangesList, 'priceChange')}
-          refundTotalVat={-getChangeTotal(priceChangesList, 'priceChangeVat')}
+          refundTotal={getChangeTotal(priceChangesList, 'priceChange')}
+          refundTotalVat={getChangeTotal(priceChangesList, 'priceChangeVat')}
           onCancel={() => setStep(ChangeVehicleStep.PRICE_PREVIEW)}
           onConfirm={updateAndNavigateToOrderView}
         />


### PR DESCRIPTION
This change should also always show the VAT for all price change lists, including refunds (previously was shown only for non-refund transactions).

## Context

[PV-711](https://helsinkisolutionoffice.atlassian.net/browse/PV-711)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

Trigger refund by changing from high to low emission vehicle in fixed period permit and continue to IBAN form step

## Screenshots

![Screenshot from 2023-11-15 16-05-22](https://github.com/City-of-Helsinki/parking-permits-ui/assets/131681805/5c21a4d1-d58b-4d9f-824f-5f8e608a9c88)



[PV-711]: https://helsinkisolutionoffice.atlassian.net/browse/PV-711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ