### PR TITLE
Fix routing to show price preview for open ended permits

### DIFF
--- a/src/pages/changeVehicle/ChangeVehicle.tsx
+++ b/src/pages/changeVehicle/ChangeVehicle.tsx
@@ -18,7 +18,6 @@ import {
 } from '../../types';
 import {
   upcomingProducts,
-  isOpenEndedPermitStarted,
   calcProductDates,
   calcProductUnitPrice,
   calcProductUnitVatPrice,
@@ -90,6 +89,7 @@ const ChangeVehicle = (): React.ReactElement => {
     const previousVatPrice = calcProductUnitVatPrice(product, false);
     const newPrice = calcProductUnitPrice(product, isLowEmission);
     const newVatPrice = calcProductUnitVatPrice(product, isLowEmission);
+
     return {
       newPrice,
       previousPrice,
@@ -121,8 +121,6 @@ const ChangeVehicle = (): React.ReactElement => {
         } else if (checkoutUrl) {
           window.open(`${checkoutUrl}`, '_self');
         }
-      } else if (isOpenEndedPermitStarted([permit])) {
-        updateAndNavigateToOrderView();
       } else {
         setStep(ChangeVehicleStep.PRICE_PREVIEW);
       }


### PR DESCRIPTION
Currently when changing to cheaper vehicle this redirects directly to "Success" screen without showing preview + IBAN form steps.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-714](https://helsinkisolutionoffice.atlassian.net/browse/PV-714)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

Follow instructions in card.

Note that product end time must be greater than the permit current period end time.

**NOTE**: the original traceback had a data error which I was unable to replicate. However I was able to solve the issue caused by the routing of open ended permits when changing the vehicle. If the data error persists, this will need to be fixed in the backend.


[PV-714]: https://helsinkisolutionoffice.atlassian.net/browse/PV-714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ