### PR TITLE
Add check for editing vehicle or address of permit

### DIFF
--- a/src/common/permit/Permit.tsx
+++ b/src/common/permit/Permit.tsx
@@ -38,6 +38,7 @@ export interface Props {
   showActionsButtons?: boolean;
   hideMap?: boolean;
   showChangeAddressButtons?: boolean;
+
   fetchPermits?: () => void;
 }
 
@@ -49,6 +50,7 @@ const Permit = ({
   hideMap = false,
   showActionsButtons = false,
   showChangeAddressButtons = false,
+
   fetchPermits,
 }: Props): React.ReactElement => {
   const dateFormat = 'd.M.yyyy HH:mm';

--- a/src/pages/validPermits/ValidPermits.tsx
+++ b/src/pages/validPermits/ValidPermits.tsx
@@ -18,7 +18,7 @@ import {
   ROUTES,
   UserAddress,
 } from '../../types';
-import { formatDate } from '../../utils';
+import { formatDate, isPermitEditable } from '../../utils';
 import './validPermits.scss';
 
 const T_PATH = 'pages.validPermit.ValidPermit';
@@ -88,6 +88,8 @@ const ValidPermits = (): React.ReactElement => {
     }
   };
 
+  const showActionsButtons = validPermits.some(isPermitEditable);
+
   return (
     <div className="valid-permit-component">
       <div className="section-label">{t(`${T_PATH}.sectionLabel`)}</div>
@@ -138,7 +140,7 @@ const ValidPermits = (): React.ReactElement => {
         <Permit
           address={address}
           permits={validPermits}
-          showActionsButtons
+          showActionsButtons={showActionsButtons}
           showChangeAddressButtons={addresses.length > 1}
           fetchPermits={permitCtx?.fetchPermits}
         />

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -211,6 +211,19 @@ export const upcomingProducts = (permit: Permit): Array<Product> =>
       dateAsNumber(product.endDate) > dateAsNumber(permit.currentPeriodEndTime)
   );
 
+// checks that permit vehicle or address can be changed
+export const isPermitEditable = (permit: Permit): boolean => {
+  if (permit.contractType === ParkingContractType.FIXED_PERIOD) {
+    return true;
+  }
+  const interval = intervalToDuration({
+    start: new Date(),
+    end: normalizeDateValue(permit.currentPeriodEndTime),
+  });
+
+  return (interval.days ?? 0) > 3;
+};
+
 export const calcProductDates = (
   product: Product,
   permit: Permit


### PR DESCRIPTION
If an open-ended permit and 3 or less days, we should not be able to change vehicle or address.

Refs: PV-724

## Context

[PV-724](https://helsinkisolutionoffice.atlassian.net/browse/PV-724)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

1. Create an open ended permit, starting now
2. "Change address" and "edit vehicle" links should be available
3. In Django admin, change the start time to 3 or less days before the current period end date
4. "Change address" and "edit vehicle" links should not be available

Fixed period permits should always have these links visible.

## Screenshots

![Screenshot from 2023-11-27 14-59-55](https://github.com/City-of-Helsinki/parking-permits-ui/assets/131681805/783eddc1-5f9a-4166-9576-b778ba89d876)
