### PR TITLE
Add canBeRefunded check when issuing refunds on change vehicle or ending

### DIFF
--- a/src/graphql/permits.graphql
+++ b/src/graphql/permits.graphql
@@ -15,6 +15,7 @@ query Query {
     monthCount
     monthsLeft
     currentPeriodEndTime
+    canBeRefunded
     canEndImmediately
     canEndAfterCurrentPeriod
     hasRefund

--- a/src/pages/changeVehicle/ChangeVehicle.tsx
+++ b/src/pages/changeVehicle/ChangeVehicle.tsx
@@ -121,8 +121,10 @@ const ChangeVehicle = (): React.ReactElement => {
         } else if (checkoutUrl) {
           window.open(`${checkoutUrl}`, '_self');
         }
-      } else {
+      } else if (permit.canBeRefunded) {
         setStep(ChangeVehicleStep.PRICE_PREVIEW);
+      } else {
+        updateAndNavigateToOrderView();
       }
     }
   };

--- a/src/pages/endPermit/EndPermit.tsx
+++ b/src/pages/endPermit/EndPermit.tsx
@@ -48,14 +48,16 @@ const EndPermit = (): React.ReactElement => {
 
     ({
       vehicle: permit.vehicle,
-      priceChanges: upcomingProducts(permit).map(product => ({
-        product: product.name,
-        previousPrice: product.unitPrice,
-        newPrice: product.unitPrice,
-        priceChange: product.unitPrice,
-        priceChangeVat: product.vat * product.unitPrice,
-        ...calcProductDates(product, permit),
-      })),
+      priceChanges: permit.canBeRefunded
+        ? upcomingProducts(permit).map(product => ({
+            product: product.name,
+            previousPrice: product.unitPrice,
+            newPrice: product.unitPrice,
+            priceChange: product.unitPrice,
+            priceChangeVat: product.vat * product.unitPrice,
+            ...calcProductDates(product, permit),
+          }))
+        : [],
     })
   );
 

--- a/src/types/permits.ts
+++ b/src/types/permits.ts
@@ -52,6 +52,7 @@ export type Permit = {
   canEndImmediately: boolean;
   hasRefund: boolean;
   monthlyPrice: number;
+  canBeRefunded: boolean;
   canEndAfterCurrentPeriod: boolean;
   vehicleChanged: boolean;
   zoneChanged: boolean;


### PR DESCRIPTION
## Context

[PV-734](https://helsinkisolutionoffice.atlassian.net/browse/PV-734)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

**NOTE** must be tested with https://github.com/City-of-Helsinki/parking-permits/pull/432

Create an open ended permit, starting immediately, high emission vehicle

Change to low emission vehicle

Repeat the same when ending permit

If no refund is due, the refund preview page should not be shown. If ending a permit with refund (e.g. fixed period multiple month permit) preview should be shown as normal.

[PV-734]: https://helsinkisolutionoffice.atlassian.net/browse/PV-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ