### PR TITLE
Remove copyright messages from vehicle error notifications

### DIFF
--- a/src/common/editPermits/VehicleDetails.tsx
+++ b/src/common/editPermits/VehicleDetails.tsx
@@ -85,7 +85,6 @@ const VehicleDetails: FC<Props> = ({
       {error && (
         <Notification type="error" className="error-notification">
           {t(error || '')}
-          <div>{t('pages.permitPrices.PermitPrices.vehicleCopyright')}</div>
         </Notification>
       )}
 

--- a/src/pages/permitPrices/permitPrices.scss
+++ b/src/pages/permitPrices/permitPrices.scss
@@ -19,6 +19,9 @@
   .restriction {
     margin-bottom: var(--spacing-s);
   }
+  .error-notification {
+    white-space: pre;
+  }
   .offer-container {
     display: flex;
     justify-content: space-between;

--- a/src/pages/vehicleSelector/VehicleSelector.tsx
+++ b/src/pages/vehicleSelector/VehicleSelector.tsx
@@ -30,7 +30,6 @@ const VehicleSelector = (): React.ReactElement => {
       {permitCtx?.getStatus() === 'error' && (
         <Notification type="error" className="error-notification">
           {t(permitCtx?.getErrorMessage() || '')}
-          <div>{t(`${T_PATH}.vehicleCopyright`)}</div>
         </Notification>
       )}
       <Outlet />

--- a/src/pages/vehicleSelector/vehicleSelector.scss
+++ b/src/pages/vehicleSelector/vehicleSelector.scss
@@ -12,4 +12,7 @@
   .purchase-amount-info {
     margin-bottom: var(--spacing-s);
   }
+  .error-notification {
+    white-space: pre;
+  }
 }


### PR DESCRIPTION
Traficom attribution should be in the server error, so not needed here.

Also added white-space: pre to CSS to ensure line breaks are handled correctly.



## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-757](https://helsinkisolutionoffice.atlassian.net/browse/PV-757)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

As user 290200A905H, add new permit with registration CPV-530 (decommissioned vehicle).

## Screenshots

![Screenshot from 2023-12-29 08-45-02](https://github.com/City-of-Helsinki/parking-permits-ui/assets/131681805/7db1618f-3d32-4981-bb29-ea2d163ff878)


[PV-757]: https://helsinkisolutionoffice.atlassian.net/browse/PV-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ