### PR TITLE
Add extra state to handle two sets of radio buttons

### DIFF
--- a/src/common/permitType/PermitType.tsx
+++ b/src/common/permitType/PermitType.tsx
@@ -23,12 +23,20 @@ const T_PATH = 'common.permitType.PermitType';
 export interface Props {
   primaryPermit: Permit;
   mainPermitToUpdate: Permit;
+  isContractTypeChecked: boolean;
+  isStartTypeChecked: boolean;
   updatePermitData: (payload: Partial<Permit>, permitId?: string) => void;
+  updateContractType: (payload: Partial<Permit>, permitId?: string) => void;
+  updateStartType: (payload: Partial<Permit>, permitId?: string) => void;
 }
 const PermitType = ({
   primaryPermit,
   mainPermitToUpdate,
+  isContractTypeChecked,
+  isStartTypeChecked,
   updatePermitData,
+  updateContractType,
+  updateStartType,
 }: Props): React.ReactElement => {
   const { t, i18n } = useTranslation();
 
@@ -60,10 +68,10 @@ const PermitType = ({
               }
               checked={
                 mainPermitToUpdate.contractType ===
-                ParkingContractType.OPEN_ENDED
+                  ParkingContractType.OPEN_ENDED && isContractTypeChecked
               }
               onClick={() =>
-                updatePermitData({
+                updateContractType({
                   contractType: ParkingContractType.OPEN_ENDED,
                   monthCount: 1,
                 })
@@ -87,10 +95,10 @@ const PermitType = ({
               label={t(`${T_PATH}.fixedPeriod`)}
               checked={
                 mainPermitToUpdate.contractType ===
-                ParkingContractType.FIXED_PERIOD
+                  ParkingContractType.FIXED_PERIOD && isContractTypeChecked
               }
               onClick={() =>
-                updatePermitData({
+                updateContractType({
                   contractType: ParkingContractType.FIXED_PERIOD,
                 })
               }
@@ -107,10 +115,11 @@ const PermitType = ({
               value={ParkingStartType.IMMEDIATELY}
               label={t(`${T_PATH}.immediately`)}
               checked={
-                mainPermitToUpdate.startType === ParkingStartType.IMMEDIATELY
+                mainPermitToUpdate.startType === ParkingStartType.IMMEDIATELY &&
+                isStartTypeChecked
               }
               onClick={() =>
-                updatePermitData({
+                updateStartType({
                   startType: ParkingStartType.IMMEDIATELY,
                   startTime: new Date().toISOString(),
                 })
@@ -126,9 +135,12 @@ const PermitType = ({
               id={uuidv4()}
               value={ParkingStartType.FROM}
               label={t(`${T_PATH}.startDate`)}
-              checked={mainPermitToUpdate.startType === ParkingStartType.FROM}
+              checked={
+                mainPermitToUpdate.startType === ParkingStartType.FROM &&
+                isStartTypeChecked
+              }
               onClick={() =>
-                updatePermitData({
+                updateStartType({
                   startType: ParkingStartType.FROM,
                   startTime: startOfDay(addDays(new Date(), 1)),
                 })


### PR DESCRIPTION

The default state e.g. OPEN_ENDED is already set in the backend database, so instead we only check these fields if either set manually by the user or if non-Draft permit.

In addition, the "Continue" button should be disabled if these radio buttons are unselected.


## Description

<!-- Describe your changes in detail -->

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-723](https://helsinkisolutionoffice.atlassian.net/browse/PV-723)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

Try to purchase new permit, and also purchase a secondary vehicle.

## Screenshots

![Screenshot from 2024-01-15 15-50-49](https://github.com/City-of-Helsinki/parking-permits-ui/assets/131681805/8d4cd0f5-2d3b-4af5-b2b5-a806381f36e8)


[PV-723]: https://helsinkisolutionoffice.atlassian.net/browse/PV-723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ