### PR TITLE
Only show Traficom copyright notice if the vehicle has been updated from

### DIFF
--- a/src/common/editPermits/PriceChangePreview.tsx
+++ b/src/common/editPermits/PriceChangePreview.tsx
@@ -119,9 +119,11 @@ const PriceChangePreview: React.FC<PriceChangePreviewProps> = ({
             <div className="vehicle">
               {formatVehicle((permit?.vehicle as Vehicle) || vehicle)}
             </div>
-            <div className="vehicle-copyright">
-              {t(`${T_PATH}.vehicleCopyright`)}
-            </div>
+            {vehicle?.updatedFromTraficomOn && (
+              <div className="vehicle-copyright">
+                {t(`${T_PATH}.vehicleCopyright`)}
+              </div>
+            )}
             {priceChanges.map((priceChangeItem, index) => (
               <Fragment key={uniqueId()}>
                 {index !== 0 && <div className="divider" />}

--- a/src/common/editPermits/VehicleDetails.tsx
+++ b/src/common/editPermits/VehicleDetails.tsx
@@ -155,9 +155,11 @@ const VehicleDetails: FC<Props> = ({
                     </div>
                   </div>
                 ))}
-              <div className="vehicle-copyright">
-                {t(`${T_PATH}.vehicleCopyright`)}
-              </div>
+              {vehicle.updatedFromTraficomOn && (
+                <div className="vehicle-copyright">
+                  {t(`${T_PATH}.vehicleCopyright`)}
+                </div>
+              )}
             </div>
           </Card>
           {vehicle.isLowEmission && (

--- a/src/common/permit/Permit.tsx
+++ b/src/common/permit/Permit.tsx
@@ -148,7 +148,8 @@ const Permit = ({
 
   const getPermit = (permit: PermitModel) => {
     const activeTempVehicle = permit.activeTemporaryVehicle;
-    const { registrationNumber, manufacturer, model } = permit.vehicle;
+    const { registrationNumber, manufacturer, model, updatedFromTraficomOn } =
+      permit.vehicle;
     const permitTimes = getPermitTimes(permit);
     const contractType = getContractType(permit);
     return (
@@ -202,9 +203,11 @@ const Permit = ({
           </div>
           <div className="pp-list__title__text">
             {`${registrationNumber} ${manufacturer} ${model}`}
-            <div className="pp-list__title__vehicle-copyright">
-              {t(`${T_PATH}.vehicleCopyright`)}
-            </div>
+            {updatedFromTraficomOn && (
+              <div className="pp-list__title__vehicle-copyright">
+                {t(`${T_PATH}.vehicleCopyright`)}
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/graphql/getVehicleInformation.graphql
+++ b/src/graphql/getVehicleInformation.graphql
@@ -7,6 +7,7 @@ mutation Mutation($registration: String!) {
     manufacturer
     productionYear
     registrationNumber
+    updatedFromTraficomOn
     restrictions
   }
 }

--- a/src/graphql/permits.graphql
+++ b/src/graphql/permits.graphql
@@ -34,6 +34,7 @@ query Query {
         model
         manufacturer
         registrationNumber
+        updatedFromTraficomOn
         restrictions
       }
     }
@@ -45,6 +46,7 @@ query Query {
       manufacturer
       productionYear
       registrationNumber
+      updatedFromTraficomOn
       restrictions
     }
     address {

--- a/src/pages/durationSelector/DurationSelector.tsx
+++ b/src/pages/durationSelector/DurationSelector.tsx
@@ -182,7 +182,9 @@ const DurationSelector = (): React.ReactElement => {
               </div>
               <div className="hide-in-mobile">{getPrices(permit)}</div>
             </div>
-            <div className="vehicle-copyright">{t('vehicleCopyright')}</div>
+            {permit.vehicle.updatedFromTraficomOn && (
+              <div className="vehicle-copyright">{t('vehicleCopyright')}</div>
+            )}
             {mainPermitToUpdate.contractType ===
               ParkingContractType.OPEN_ENDED && (
               <div>{t('openEndedAssistiveText')}</div>

--- a/src/pages/permitPrices/PermitPrices.tsx
+++ b/src/pages/permitPrices/PermitPrices.tsx
@@ -129,9 +129,11 @@ const PermitPrices = (): React.ReactElement => {
                     )}
                   </div>
                   {getPrices(permit)}
-                  <div className="vehicle-copyright">
-                    {t(`${T_PATH}.vehicleCopyright`)}
-                  </div>
+                  {permit.vehicle.updatedFromTraficomOn && (
+                    <div className="vehicle-copyright">
+                      {t(`${T_PATH}.vehicleCopyright`)}
+                    </div>
+                  )}
                 </div>
               </Card>
               <div className="action-delete">

--- a/src/types/permits.ts
+++ b/src/types/permits.ts
@@ -71,6 +71,7 @@ export type Vehicle = {
   model: string;
   productionYear: number;
   registrationNumber: string;
+  updatedFromTraficomOn: MaybeDate;
   restrictions: Array<string>;
 };
 


### PR DESCRIPTION

## Description

<!-- Describe your changes in detail -->

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-690](https://helsinkisolutionoffice.atlassian.net/browse/PV-690)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

With an existing permit, set the "updated from Traficom" timestamp in Django admin to empty.  The copyright Traficom notice should be removed.

## Screenshots

![Screenshot from 2024-01-30 14-50-10](https://github.com/City-of-Helsinki/parking-permits-ui/assets/131681805/14b98a31-6a3c-4c5b-b4b3-c3d443c9a371)

![Screenshot from 2024-01-30 14-48-38](https://github.com/City-of-Helsinki/parking-permits-ui/assets/131681805/6c8f09c5-a954-43f9-8766-1ce66a1046d1)


[PV-690]: https://helsinkisolutionoffice.atlassian.net/browse/PV-690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ