### PR TITLE
Handles new maxExtensionMonthCount permit setting

### DIFF
--- a/src/common/permit/Permit.tsx
+++ b/src/common/permit/Permit.tsx
@@ -319,7 +319,7 @@ const Permit = ({
                     {t(`${T_PATH}.editVehicle`)}
                   </Button>
                 )}
-                {permit.canExtendPermit && (
+                {permit.canExtendPermit && permit.maxExtensionMonthCount > 0 && (
                   <Button
                     variant="supplementary"
                     iconLeft={<IconAngleRight />}

--- a/src/graphql/permits.graphql
+++ b/src/graphql/permits.graphql
@@ -19,6 +19,7 @@ query Query {
     canEndImmediately
     canEndAfterCurrentPeriod
     canExtendPermit
+    maxExtensionMonthCount
     hasPendingExtensionRequest
     totalRefundAmount
     hasRefund

--- a/src/pages/extendPermit/ExtendPermit.tsx
+++ b/src/pages/extendPermit/ExtendPermit.tsx
@@ -23,8 +23,6 @@ import {
 } from '../../graphql/permitGqlClient';
 import './extendPermit.scss';
 
-const MAX_MONTHS = 12;
-
 // TBD use own Path
 const T_PATH = 'pages.extendPermit.ExtendPermit';
 
@@ -119,12 +117,12 @@ const ExtendPermit = (): React.ReactElement => {
             className="month-selection"
             id={uuidv4()}
             helperText={t('monthSelectionHelpText', {
-              max: MAX_MONTHS,
+              max: permit.maxExtensionMonthCount,
             })}
             label=""
             min={1}
             step={1}
-            max={MAX_MONTHS}
+            max={permit.maxExtensionMonthCount}
             defaultValue={monthCount}
             disabled={isLoading}
             onChange={(e: React.ChangeEvent<HTMLInputElement>): void => {

--- a/src/types/permits.ts
+++ b/src/types/permits.ts
@@ -52,6 +52,7 @@ export type Permit = {
   currentPeriodEndTime: Date | string;
   canEndImmediately: boolean;
   canExtendPermit: boolean;
+  maxExtensionMonthCount: number;
   hasPendingExtensionRequest: boolean;
   hasRefund: boolean;
   monthlyPrice: number;


### PR DESCRIPTION


<!-- Describe your changes in detail -->

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-793](https://helsinkisolutionoffice.atlassian.net/browse/PV-793)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

Create first fixed term permit 3 months from now.

Create second permit for 1 month, and adjust dates so you can extend the permit (end time < 14 days).

You should only be able to extend the permit by 2-3 months depending on end date of 1st permit.

If no available months, you should not see the "Extend permit" button for the second permit.

[PV-793]: https://helsinkisolutionoffice.atlassian.net/browse/PV-793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ