### PR TITLE
Add credit card update link to permit page

### DIFF
--- a/src/common/permit/Permit.tsx
+++ b/src/common/permit/Permit.tsx
@@ -246,6 +246,9 @@ const Permit = ({
     p => p.startTime && dateAsNumber(p.startTime) < new Date().valueOf()
   );
 
+  const updateCardUrl = permits.filter(p => !!p.updateCardUrl)[0]
+    ?.updateCardUrl;
+
   return (
     <div className="permit-component">
       {!hideMap && (
@@ -317,6 +320,14 @@ const Permit = ({
                     onClick={() => setEditPermitId(permit.id)}
                     iconLeft={<IconAngleRight />}>
                     {t(`${T_PATH}.editVehicle`)}
+                  </Button>
+                )}
+                {updateCardUrl && (
+                  <Button
+                    variant="supplementary"
+                    onClick={() => navigate(updateCardUrl)}
+                    iconLeft={<IconAngleRight />}>
+                    {t(`${T_PATH}.updateCard`)}
                   </Button>
                 )}
                 {permit.canExtendPermit && permit.maxExtensionMonthCount > 0 && (

--- a/src/graphql/permits.graphql
+++ b/src/graphql/permits.graphql
@@ -4,6 +4,7 @@ query Query {
     talpaOrderId
     receiptUrl
     checkoutUrl
+    updateCardUrl
     subscriptionId
     startType
     startTime

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -118,6 +118,7 @@
   "common.permit.Permit.deleteTemporaryVehicle": "Delete temporary vehicle",
   "common.permit.Permit.discount": "You are entitled to reduced street parking with mobile apps when you pay.",
   "common.permit.Permit.editVehicle": "Edit vehicle information",
+  "common.permit.Permit.updateCard": "Edit credit card information",
   "common.permit.Permit.endTime": "End",
   "common.permit.Permit.invalidPermit": "Invalid permit",
   "common.permit.Permit.label": "Your parking permit",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -118,6 +118,7 @@
   "common.permit.Permit.deleteTemporaryVehicle": "Poista tilapäinen ajoneuvo",
   "common.permit.Permit.discount": "Olet oikeutettu alennettuun kadunvarsipysäköintiin mobiilisovelluksilla maksaessasi.",
   "common.permit.Permit.editVehicle": "Muokkaa ajoneuvon tietoja",
+  "common.permit.Permit.updateCard": "Muokkaa luottokortin tietoja",
   "common.permit.Permit.extendPermit": "Jatka pysäköintitunnuksen voimassaoloa",
   "common.permit.Permit.endTime": "Päättyy",
   "common.permit.Permit.invalidPermit": "Ei voimassa",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -118,6 +118,7 @@
   "common.permit.Permit.deleteTemporaryVehicle": "Ta bort tillfälligt fordon",
   "common.permit.Permit.discount": "Du har rätt till rabatt på gatuparkering när du betalar med mobilappar.",
   "common.permit.Permit.editVehicle": "Redigera fordonsinformation",
+  "common.permit.Permit.updateCard": "Redigera kreditkortsinformation",
   "common.permit.Permit.endTime": "Slutar",
   "common.permit.Permit.invalidPermit": "Inte i kraft",
   "common.permit.Permit.label": "Ditt parkeringstillstånd",

--- a/src/types/permits.ts
+++ b/src/types/permits.ts
@@ -34,6 +34,7 @@ export type Permit = {
   talpaOrderId: string;
   receiptUrl: string;
   checkoutUrl: string;
+  updateCardUrl: string;
   startType?: ParkingStartType;
   startTime?: MaybeDate;
   endTime?: MaybeDate;


### PR DESCRIPTION
Refs: PV-816

## Description

<!-- Describe your changes in detail -->

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-816](https://helsinkisolutionoffice.atlassian.net/browse/PV-816)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

1. In Django admin, find a valid parking permit and click the "Latest order" link.
2. Change the "Latest order" field "update card url" field to some URL
3. In Webshop, log in as the permit holder.

The "Update credit card" link should be shown for that permit.

## Screenshots

<!-- Add screenshots if appropriate -->

![Screenshot from 2024-03-22 08-52-12](https://github.com/City-of-Helsinki/parking-permits-ui/assets/131681805/7404b2ec-9fad-4511-b857-85114efd3a3c)



[PV-816]: https://helsinkisolutionoffice.atlassian.net/browse/PV-816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ