### PR TITLE
Add credit card update link to permit page

### DIFF
--- a/src/common/permit/Permit.tsx
+++ b/src/common/permit/Permit.tsx
@@ -322,14 +322,6 @@ const Permit = ({
                     {t(`${T_PATH}.editVehicle`)}
                   </Button>
                 )}
-                {updateCardUrl && (
-                  <Button
-                    variant="supplementary"
-                    onClick={() => navigate(updateCardUrl)}
-                    iconLeft={<IconAngleRight />}>
-                    {t(`${T_PATH}.updateCard`)}
-                  </Button>
-                )}
                 {permit.canExtendPermit && permit.maxExtensionMonthCount > 0 && (
                   <Button
                     variant="supplementary"
@@ -375,6 +367,16 @@ const Permit = ({
                     })
                   }
                 />
+              </div>
+            )}
+            {updateCardUrl && (
+              <div className="permit-action-btns">
+                <Button
+                  variant="supplementary"
+                  onClick={() => window.open(updateCardUrl, '_self')}
+                  iconLeft={<IconAngleRight />}>
+                  {t(`${T_PATH}.updateCard`)}
+                </Button>
               </div>
             )}
           </Card>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -118,7 +118,7 @@
   "common.permit.Permit.deleteTemporaryVehicle": "Delete temporary vehicle",
   "common.permit.Permit.discount": "You are entitled to reduced street parking with mobile apps when you pay.",
   "common.permit.Permit.editVehicle": "Edit vehicle information",
-  "common.permit.Permit.updateCard": "Edit credit card information",
+  "common.permit.Permit.updateCard": "Edit payment card details",
   "common.permit.Permit.endTime": "End",
   "common.permit.Permit.invalidPermit": "Invalid permit",
   "common.permit.Permit.label": "Your parking permit",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -118,7 +118,7 @@
   "common.permit.Permit.deleteTemporaryVehicle": "Poista tilapäinen ajoneuvo",
   "common.permit.Permit.discount": "Olet oikeutettu alennettuun kadunvarsipysäköintiin mobiilisovelluksilla maksaessasi.",
   "common.permit.Permit.editVehicle": "Muokkaa ajoneuvon tietoja",
-  "common.permit.Permit.updateCard": "Muokkaa luottokortin tietoja",
+  "common.permit.Permit.updateCard": "Muokkaa maksukortin tietoja",
   "common.permit.Permit.extendPermit": "Jatka pysäköintitunnuksen voimassaoloa",
   "common.permit.Permit.endTime": "Päättyy",
   "common.permit.Permit.invalidPermit": "Ei voimassa",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -118,7 +118,7 @@
   "common.permit.Permit.deleteTemporaryVehicle": "Ta bort tillfälligt fordon",
   "common.permit.Permit.discount": "Du har rätt till rabatt på gatuparkering när du betalar med mobilappar.",
   "common.permit.Permit.editVehicle": "Redigera fordonsinformation",
-  "common.permit.Permit.updateCard": "Redigera kreditkortsinformation",
+  "common.permit.Permit.updateCard": "Redigera dina betalkortsuppgifter",
   "common.permit.Permit.endTime": "Slutar",
   "common.permit.Permit.invalidPermit": "Inte i kraft",
   "common.permit.Permit.label": "Ditt parkeringstillstånd",


### PR DESCRIPTION
Refs: PV-816

## Description

<!-- Describe your changes in detail -->

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-816](https://helsinkisolutionoffice.atlassian.net/browse/PV-816)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

In Django admin, find the latest order for a permit, and change the "Talpa update card url" field to some non-empty value.

In Webshop, the link should appear in the user's home page, if the user

## Screenshots

![Screenshot from 2024-03-27 11-55-48](https://github.com/City-of-Helsinki/parking-permits-ui/assets/131681805/b72a543b-204e-4f3f-9f71-c08055d4d1e3)


[PV-816]: https://helsinkisolutionoffice.atlassian.net/browse/PV-816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ