### PR TITLE
Change search vehicle button finnish translation

### DIFF
--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -167,7 +167,7 @@
   "common.refund.Refund.terms.linkText": "käyttöehtoihin",
   "common.refund.Refund.vat": "Sis. alv (24%)",
   "common.refund.Refund.zone": "Pysäköintialue {{zone}}",
-  "common.registrationNumber.RegistrationNumber.btn": "Lisää ajoneuvo",
+  "common.registrationNumber.RegistrationNumber.btn": "Hae",
   "common.registrationNumber.RegistrationNumber.helpText": "Syötä yksi rekisterinumero kerrallaan. Käytä muotoa ABC-123.",
   "common.registrationNumber.RegistrationNumber.label": "Rekisterinumero",
   "common.restrictions.label": "Ajoneuvolla on rajoitustieto",


### PR DESCRIPTION
Refs: PV-817

## Description

When creating a new permit or adding 2. vehicle later in the webshop the button now says “Hae” instead of “Lisää ajoneuvo”.

## Context

[PV-817](https://helsinkisolutionoffice.atlassian.net/browse/PV-817)

## How Has This Been Tested?

Tested manually.

## Manual Testing Instructions for Reviewers

This can be tested by purchasing new parking permits for 1st or 2nd vehicles.

## Screenshots

<img width="641" alt="Screenshot 2024-04-11 at 16 08 49" src="https://github.com/City-of-Helsinki/parking-permits-ui/assets/41970562/9043f9a5-390b-41f1-9a8e-2068d51b8f55">


[PV-817]: https://helsinkisolutionoffice.atlassian.net/browse/PV-817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ