### PR TITLE
Add text when purchasing permits

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -130,7 +130,7 @@
   "common.permitType.PermitType.immediately": "Start immediately",
   "common.permitType.PermitType.immediatelyAssistiveText": "The permit will take effect as soon as the payment is confirmed.",
   "common.permitType.PermitType.openEnded": "Continuous charge",
-  "common.permitType.PermitType.openEndedAssistiveText": "The price of the parking permit and the terms for receiving a permit are reviewed and charged monthly. A subscription for a permit requires a card payment and the storage of card information for continuous charging.",
+  "common.permitType.PermitType.openEndedAssistiveText": "The price of the parking permit and the terms for receiving a permit are reviewed and charged monthly. The charge is made three days before the end of the parking permit. A subscription for a permit requires a card payment and the storage of card information for continuous charging.",
   "common.permitType.PermitType.parkingDurationType.label": "Duration type",
   "common.permitType.PermitType.sameAsFirstPermitNotification": "Must be the same as 1st permit",
   "common.permitType.PermitType.startDate": "From",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -131,7 +131,7 @@
   "common.permitType.PermitType.immediately": "Alkaa heti",
   "common.permitType.PermitType.immediatelyAssistiveText": "Tunnuksen voimassaolo alkaa heti siitä kellonajasta kun maksu on vahvistettu.",
   "common.permitType.PermitType.openEnded": "Jatkuvaveloitteinen kuukausitunnus",
-  "common.permitType.PermitType.openEndedAssistiveText": "Pysäköintitunnuksen hinta ja oikeus tunnuksen saamiseen tarkistetaan ja veloitetaan kuukausittain. Toistaiseksi voimassa oleva tunnus edellyttää korttimaksua ja kortin tietojen tallentamista jatkuvaa veloitusta varten.",
+  "common.permitType.PermitType.openEndedAssistiveText": "Pysäköintitunnuksen hinta ja oikeus tunnuksen saamiseen tarkistetaan ja veloitetaan kuukausittain. Veloitus tehdään kolme päivää ennen pysäköintikauden päättymistä. Toistaiseksi voimassa oleva tunnus edellyttää korttimaksua ja kortin tietojen tallentamista jatkuvaa veloitusta varten.",
   "common.permitType.PermitType.parkingDurationType.label": "Tilauksen tyyppi",
   "common.permitType.PermitType.sameAsFirstPermitNotification": "Tulee olla sama kuin 1. tunnuksessa",
   "common.permitType.PermitType.startDate": "Alkaen",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -130,7 +130,7 @@
   "common.permitType.PermitType.immediately": "Börja omedelbart",
   "common.permitType.PermitType.immediatelyAssistiveText": "Parkeringstillståndet träder i kraft så snart betalningen har bekräftats.",
   "common.permitType.PermitType.openEnded": "Månadstillstånd med kontinuerlig debitering",
-  "common.permitType.PermitType.openEndedAssistiveText": "Priset på parkeringtillståndet och rätten att få tillståndet granskas och debiteras varje månad. Ett tillfälligt tillstånd kräver kortbetalning och lagring av kortinformationen för kontinuerlig girering.",
+  "common.permitType.PermitType.openEndedAssistiveText": "Priset på parkeringtillståndet och rätten att få tillståndet granskas och debiteras varje månad. Debiteringen sker tre dagar innan parkeringstillståndet löper ut. Ett tillfälligt tillstånd kräver kortbetalning och lagring av kortinformationen för kontinuerlig girering.",
   "common.permitType.PermitType.parkingDurationType.label": "Typ av beställning",
   "common.permitType.PermitType.sameAsFirstPermitNotification": "Måste vara samma som 1:a tillståndet",
   "common.permitType.PermitType.startDate": "Från",


### PR DESCRIPTION
Refs: PV-828

## Description

Add text to fin/sv/en translations when purchasing permits.

## Context

[PV-828](https://helsinkisolutionoffice.atlassian.net/browse/PV-828)

## How Has This Been Tested?

Tested manually.

## Manual Testing Instructions for Reviewers

Text should be visible for fi/sv/en translations when purchasing a permit.

## Screenshots

<img width="1157" alt="Screenshot 2024-04-17 at 14 11 03" src="https://github.com/City-of-Helsinki/parking-permits-ui/assets/41970562/617f4e37-6d48-422c-9ac1-6187883141e7">
<img width="1168" alt="Screenshot 2024-04-17 at 14 11 12" src="https://github.com/City-of-Helsinki/parking-permits-ui/assets/41970562/411cf380-a671-49fd-b3e4-a254f200fe14">
<img width="1151" alt="Screenshot 2024-04-17 at 14 11 19" src="https://github.com/City-of-Helsinki/parking-permits-ui/assets/41970562/505fb25b-33e9-4b0f-8420-2fdf4df79167">


[PV-828]: https://helsinkisolutionoffice.atlassian.net/browse/PV-828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ