### PR TITLE
Hide payment info edit option for fixed permits

### DIFF
--- a/src/common/permit/Permit.tsx
+++ b/src/common/permit/Permit.tsx
@@ -369,7 +369,7 @@ const Permit = ({
                 />
               </div>
             )}
-            {updateCardUrl && (
+            {updateCardUrl && permit.contractType !== 'FIXED_PERIOD' && (
               <div className="permit-action-btns">
                 <Button
                   variant="supplementary"


### PR DESCRIPTION
## Description

Fixed permits do not have saved payment information. This PR hides the option to update payment information for fixed period permits.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-866](https://helsinkisolutionoffice.atlassian.net/browse/PV-866)

## How Has This Been Tested?

Manually looking at the UI after changes.

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

![image](https://github.com/user-attachments/assets/909a83fb-d834-484e-a339-fcd6f1765352)


[PV-866]: https://helsinkisolutionoffice.atlassian.net/browse/PV-866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ