### PR TITLE
Add support for webshop permit preliminary status

### DIFF
--- a/src/common/permit/Permit.tsx
+++ b/src/common/permit/Permit.tsx
@@ -71,7 +71,8 @@ const Permit = ({
   const isProcessing = (permit: PermitModel) =>
     (permit.status === PermitStatus.PAYMENT_IN_PROGRESS &&
       permit.talpaOrderId) ||
-    (permit.status === PermitStatus.DRAFT && permit.isOrderConfirmed);
+    (permit.status === (PermitStatus.DRAFT || PermitStatus.PRELIMINARY) &&
+      permit.isOrderConfirmed);
   const hasTemporaryVehicle = (permit: PermitModel) =>
     permit.activeTemporaryVehicle;
 

--- a/src/common/purchaseNotification/PurchaseNotification.tsx
+++ b/src/common/purchaseNotification/PurchaseNotification.tsx
@@ -35,6 +35,7 @@ const PurchaseNotification = ({ validPermits }: Props): React.ReactElement => {
     const isAlert = validPermits.some(
       permit =>
         permit.status === PermitStatus.DRAFT ||
+        permit.status === PermitStatus.PRELIMINARY ||
         permit.status === PermitStatus.PAYMENT_IN_PROGRESS ||
         permit.hasPendingExtensionRequest
     );

--- a/src/hooks/permitHook.ts
+++ b/src/hooks/permitHook.ts
@@ -136,7 +136,11 @@ const usePermitState = (): PermitActions => {
     fetchPermits: (): Promise<void> => fetchPermits(),
     getDraftPermits: () =>
       permits
-        .filter(permit => permit.status === PermitStatus.DRAFT)
+        .filter(
+          permit =>
+            permit.status === PermitStatus.DRAFT ||
+            permit.status === PermitStatus.PRELIMINARY
+        )
         .sort(a => (a.primaryVehicle ? -1 : 1)),
     getValidPermits: () =>
       permits.filter(
@@ -144,7 +148,9 @@ const usePermitState = (): PermitActions => {
           [PermitStatus.VALID, PermitStatus.PAYMENT_IN_PROGRESS].includes(
             permit.status
           ) ||
-          (permit.status === PermitStatus.DRAFT && permit.isOrderConfirmed)
+          ((permit.status === PermitStatus.DRAFT ||
+            permit.status === PermitStatus.PRELIMINARY) &&
+            permit.isOrderConfirmed)
       ),
     getChangeAddressPriceChanges,
     changeAddress: (addressId, iban) => changeAddressRequest(addressId, iban),

--- a/src/pages/durationSelector/DurationSelector.tsx
+++ b/src/pages/durationSelector/DurationSelector.tsx
@@ -69,7 +69,9 @@ const DurationSelector = (): React.ReactElement => {
   }
   const mainPermitToUpdate = validPermits?.length ? otherPermit : primaryPermit;
 
-  const isDraft = mainPermitToUpdate?.status === PermitStatus.DRAFT;
+  const isDraft =
+    mainPermitToUpdate?.status === PermitStatus.DRAFT ||
+    PermitStatus.PRELIMINARY;
   const isContractTypeChecked = !isDraft || contractTypeChecked;
   const isStartTypeChecked = !isDraft || startTypeChecked;
   const isChecked = isContractTypeChecked && isStartTypeChecked;

--- a/src/pages/validPermits/ValidPermits.tsx
+++ b/src/pages/validPermits/ValidPermits.tsx
@@ -50,7 +50,9 @@ const ValidPermits = (): React.ReactElement => {
   const isProcessing = (permit: PermitModel) =>
     (permit.status === PermitStatus.PAYMENT_IN_PROGRESS &&
       permit.talpaOrderId) ||
-    (permit.status === PermitStatus.DRAFT && permit.isOrderConfirmed) ||
+    ((permit.status === PermitStatus.DRAFT ||
+      permit.status === PermitStatus.PRELIMINARY) &&
+      permit.isOrderConfirmed) ||
     permit.hasPendingExtensionRequest;
 
   const hasVehicleChanged = (permit: PermitModel) => permit.vehicleChanged;
@@ -105,7 +107,9 @@ const ValidPermits = (): React.ReactElement => {
 
       {validPermits.some(
         permit =>
-          permit.status === PermitStatus.DRAFT && permit.isOrderConfirmed
+          (permit.status === PermitStatus.DRAFT ||
+            permit.status === PermitStatus.PRELIMINARY) &&
+          permit.isOrderConfirmed
       ) && (
         <Notification
           type="alert"

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -40,6 +40,7 @@ export enum ParkingStartType {
 
 export enum PermitStatus {
   DRAFT = 'DRAFT',
+  PRELIMINARY = 'PRELIMINARY',
   PAYMENT_IN_PROGRESS = 'PAYMENT_IN_PROGRESS',
   VALID = 'VALID',
   CANCELLED = 'CANCELLED',


### PR DESCRIPTION
## Description

Add support for webshop permit `PRELIMINARY`-status.

## Context

[PV-898](https://helsinkisolutionoffice.atlassian.net/browse/PV-898)

## How Has This Been Tested?

Manually in Webshop.

## Manual Testing Instructions for Reviewers

Test to buy permit with `PRELIMINARY`-status.

## Screenshots
![preliminary webshop permit bought](https://github.com/user-attachments/assets/2bafac24-398e-4747-ae97-ab28f995568b)




[PV-898]: https://helsinkisolutionoffice.atlassian.net/browse/PV-898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ