### PR TITLE
Apollo-client as a module

### DIFF
--- a/src/client/LoginProvider.tsx
+++ b/src/client/LoginProvider.tsx
@@ -1,7 +1,8 @@
 import { LoginProvider } from 'hds-react';
-import React, { FC } from 'react';
+import React, { FC, useMemo } from 'react';
 
 import { getHDSClientConfig } from '.';
+import { createGraphQLClientModule } from '../hooks/graphqlClientModule';
 
 interface HDSLoginProviderProps {
   children: React.ReactNode;
@@ -9,8 +10,13 @@ interface HDSLoginProviderProps {
 
 const HDSLoginProvider: FC<HDSLoginProviderProps> = ({ children }) => {
   const loginProviderProps = getHDSClientConfig();
+  const graphqlModule = useMemo(() => createGraphQLClientModule(), []);
 
-  return <LoginProvider {...loginProviderProps}>{children}</LoginProvider>;
+  return (
+    <LoginProvider {...loginProviderProps} modules={[graphqlModule]}>
+      {children}
+    </LoginProvider>
+  );
 };
 
 export default HDSLoginProvider;

--- a/src/graphql/permitGqlClient.ts
+++ b/src/graphql/permitGqlClient.ts
@@ -1,7 +1,7 @@
 import { OperationVariables } from '@apollo/client/core/types';
 import { DocumentNode } from 'graphql';
 import { loader } from 'graphql.macro';
-import { getGqlClient } from '../hooks/utils';
+import { getGqlClient } from '../hooks/graphqlClientModule';
 import {
   addTemporaryVehicle,
   ChangeAddressResult,

--- a/src/hooks/graphqlClientModule.ts
+++ b/src/hooks/graphqlClientModule.ts
@@ -1,0 +1,156 @@
+import {
+  Beacon,
+  ConnectedModule,
+  createTriggerPropsForAllApiTokensClientSignals,
+  Disposer,
+  isApiTokensRemovedSignal,
+  isApiTokensUpdatedSignal,
+  SignalListener,
+  TokenData,
+  useConnectedModule,
+  getApiTokensClientEventPayload,
+} from 'hds-react';
+import {
+  ApolloClient,
+  ApolloLink,
+  from,
+  DefaultOptions,
+  HttpLink,
+  InMemoryCache,
+  NormalizedCacheObject,
+} from '@apollo/client';
+import { getEnv } from '../utils';
+
+import { FetchError } from '../client/types';
+import i18n from '../i18n/i18n';
+
+export type GraphQLClient = ApolloClient<NormalizedCacheObject>;
+export type GraphQLClientError = Pick<FetchError, 'error' | 'message'>;
+type GraphQLClientModule = ConnectedModule & {
+  getClient: () => GraphQLClient;
+  resetClient: () => Promise<void>;
+};
+
+let gqlClient: GraphQLClient;
+
+const defaultOptions: DefaultOptions = {
+  mutate: {
+    errorPolicy: 'all',
+  },
+  query: {
+    fetchPolicy: 'no-cache',
+    errorPolicy: 'all',
+  },
+};
+
+export function createGraphQLClient(
+  uri: string,
+  apiTokensLink: ApolloLink
+): GraphQLClient {
+  const httpLink = new HttpLink({ uri });
+  const languageLink = new ApolloLink((operation, forward) => {
+    operation.setContext(({ headers = {} }) => ({
+      headers: {
+        ...headers,
+        'Content-Language': i18n.language,
+        'Accept-Language': i18n.language,
+      },
+    }));
+    return forward(operation);
+  });
+  return new ApolloClient({
+    defaultOptions,
+    cache: new InMemoryCache(),
+    link: from([apiTokensLink, languageLink, httpLink]),
+  });
+}
+
+function getNamedTokens(tokens: TokenData) {
+  if (!tokens) {
+    return undefined;
+  }
+  const parkingPermitsTokenKey = getEnv('REACT_APP_TOKEN_KEY');
+  const profileTokenKey = getEnv('REACT_APP_PROFILE_TOKEN_KEY');
+  const parkingPermitsApiToken = tokens[parkingPermitsTokenKey];
+  const helsinkiProfileApiToken = tokens[profileTokenKey];
+  return {
+    parkingPermitsApiToken,
+    helsinkiProfileApiToken,
+  };
+}
+
+const namespace = 'graphQLClientModule';
+// eslint-disable-next-line import/prefer-default-export
+export function createGraphQLClientModule(): GraphQLClientModule {
+  let beacon: Beacon | undefined;
+  const uri = getEnv('REACT_APP_PARKING_PERMITS_BACKEND_URL');
+  const tokens = {
+    parkingPermitsApiToken: '',
+    helsinkiProfileApiToken: '',
+  };
+
+  const authLink = new ApolloLink((operation, forward) => {
+    operation.setContext(({ headers = {} }) => ({
+      headers: {
+        ...headers,
+        Authorization: `Bearer ${tokens.parkingPermitsApiToken}`,
+        'X-Authorization': `Bearer ${tokens.helsinkiProfileApiToken}`,
+      },
+    }));
+    return forward(operation);
+  });
+
+  const client = createGraphQLClient(uri, authLink);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  gqlClient = client;
+  const listener: SignalListener = signal => {
+    if (isApiTokensUpdatedSignal(signal)) {
+      const payload = getApiTokensClientEventPayload(signal);
+      const newTokens = getNamedTokens(payload?.data as TokenData);
+      tokens.helsinkiProfileApiToken = newTokens
+        ? newTokens.helsinkiProfileApiToken
+        : '';
+      tokens.parkingPermitsApiToken = newTokens
+        ? newTokens.parkingPermitsApiToken
+        : '';
+      //
+    } else if (isApiTokensRemovedSignal(signal)) {
+      // ignoring removal and keeping old tokens until renewed.
+    }
+  };
+  let listenerDisposer: Disposer;
+  return {
+    namespace,
+    connect: connectedBeacon => {
+      // connect may be called twice if StrictMode
+      // or LoginProvider is nested inside another context
+      if (listenerDisposer) {
+        listenerDisposer();
+      }
+      beacon = connectedBeacon;
+      listenerDisposer = beacon.addListener(
+        createTriggerPropsForAllApiTokensClientSignals(),
+        listener
+      );
+    },
+    getClient: () => client,
+    resetClient: async () => {
+      client.stop();
+      await client.resetStore();
+    },
+  };
+}
+
+// hook to get the client
+export function useGraphQLClient(): GraphQLClient {
+  const module = useConnectedModule<GraphQLClientModule>(namespace);
+  if (!module) {
+    throw new Error('Cannot find graphQLModule from LoginContext.');
+  }
+  return module.getClient();
+}
+
+// function to get the stored client
+export function getGqlClient(): GraphQLClient | undefined {
+  return gqlClient;
+}

--- a/src/hooks/userProfileHook.ts
+++ b/src/hooks/userProfileHook.ts
@@ -13,8 +13,8 @@ import {
   UserProfile,
 } from '../types';
 import { formatErrors } from '../utils';
-import { getGqlClient } from './utils';
 import { useIsAuthorizationReady } from '../client/useIsAuthReady';
+import { getGqlClient } from './graphqlClientModule';
 
 const useProfile = (): ProfileActions => {
   const tokens = getApiTokensFromStorage();


### PR DESCRIPTION
## Description

Create and connect the ApolloClient as a module to the LoginProvider.

This way the Client is integrated to apiTokens and gets new ones everytime it they update.

## How Has This Been Tested?

Manually.

## Manual Testing Instructions for Reviewers

Just login.

## Screenshots

<!-- Add screenshots if appropriate -->
