### PR TITLE
SHPPWS-93: Update end permit dialog messages and date format

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -83,7 +83,7 @@
   "common.editPermits.SelectAddress.actionBtn.continue": "Continue",
   "common.editPermits.SelectAddress.title": "Confirm new address",
   "common.endPermitDialog.EndPermitDialog.cancel": "Cancel",
-  "common.endPermitDialog.EndPermitDialog.choosePermitEndType": "Choose when the permit is ended",
+  "common.endPermitDialog.EndPermitDialog.choosePermitEndType": "Choose when the permit is ended (refunds will be generated automatically for the remaining paid months of the permit):)",
   "common.endPermitDialog.EndPermitDialog.continue": "Continue",
   "common.endPermitDialog.EndPermitDialog.endAfterCurrentPeriod": "End permit after current period",
   "common.endPermitDialog.EndPermitDialog.endImmediately": "End permit immediately",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -83,7 +83,7 @@
   "common.editPermits.SelectAddress.actionBtn.continue": "Jatka",
   "common.editPermits.SelectAddress.title": "Vahvista uusi osoite",
   "common.endPermitDialog.EndPermitDialog.cancel": "Peruuta",
-  "common.endPermitDialog.EndPermitDialog.choosePermitEndType": "Valitsen milloin tunnuksen voimassaolo päättyy",
+  "common.endPermitDialog.EndPermitDialog.choosePermitEndType": "Valitse milloin tunnuksen voimassaolo päättyy (kokonaisista tunnuksen jäljellä olevista maksetuista kuukausista muodostetaan palautukset automaattisesti):",
   "common.endPermitDialog.EndPermitDialog.continue": "Jatka",
   "common.endPermitDialog.EndPermitDialog.endAfterCurrentPeriod": "Päätä tunnus kuluvan kauden päätteeksi",
   "common.endPermitDialog.EndPermitDialog.endImmediately": "Päätä tunnus välittömästi",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -83,7 +83,7 @@
   "common.editPermits.SelectAddress.actionBtn.continue": "Fortsätt",
   "common.editPermits.SelectAddress.title": "Bekräfta ny adress",
   "common.endPermitDialog.EndPermitDialog.cancel": "Avbryt",
-  "common.endPermitDialog.EndPermitDialog.choosePermitEndType": "Välj när tillståndet upphör",
+  "common.endPermitDialog.EndPermitDialog.choosePermitEndType": "Välj när tillståndet upphör (återbetalningar genereras automatiskt för de återstående betalda månaderna av tillståndet):",
   "common.endPermitDialog.EndPermitDialog.continue": "Fortsätt",
   "common.endPermitDialog.EndPermitDialog.endAfterCurrentPeriod": "Avsluta tillståndet efter pågående period",
   "common.endPermitDialog.EndPermitDialog.endImmediately": "Avsluta tillstånd omedelbart",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,8 @@ import {
 
 const PC_100 = 100;
 
+const dateFormat = 'd.M.yyyy HH:mm';
+
 type TranslateFunction = (name: string) => string;
 
 type Restrictions = {
@@ -88,9 +90,7 @@ export function getBooleanEnv(key: string): boolean {
 
 export function formatDateTimeDisplay(datetime: MaybeDate): string {
   const dt = normalizeDateValue(datetime);
-  const dateStr = dt.toLocaleDateString('fi');
-  const timeStr = dt.toLocaleTimeString('fi');
-  return `${dateStr}, ${timeStr}`;
+  return format(dt, dateFormat);
 }
 
 export const formatDate = (date: MaybeDate): string =>


### PR DESCRIPTION
## Description

Updates:
- Update permit end dialog fi/sv/en-messages
- Update date format to matct other date formats in the application

## Screenshots

![tunnuksen päättäminen 3pv](https://github.com/user-attachments/assets/1a92b0fa-407e-474f-834d-c0aad3783540)

