### PR TITLE
SHPPWS-115: vehicle validation improvement

### DIFF
--- a/src/common/editPermits/VehicleDetails.tsx
+++ b/src/common/editPermits/VehicleDetails.tsx
@@ -33,6 +33,7 @@ import {
 } from '../../utils';
 import './vehicleDetails.scss';
 import DiscountLabel from '../discountLabel/DiscountLabel';
+import { ErrorStateContext, ErrorStateDict } from '../../hooks/errorProvider';
 
 const T_PATH = 'common.editPermits.ChangeVehicle';
 
@@ -56,10 +57,13 @@ const VehicleDetails: FC<Props> = ({
   const { t } = useTranslation();
   const navigate = useNavigate();
   const permitCtx = useContext(PermitStateContext);
-  const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [tempRegistration, setTempRegistration] = useState('');
-
+  const errorState = useContext(ErrorStateContext);
+  // type cast is used to get around some typing ugliness concerning state setter methods
+  // and context default value initialization, see type declaration of
+  // ErrorStateContextDefaultValue for more information.
+  const { error, setError } = errorState as ErrorStateDict;
   const inputRegistration = (event: { target: { value: string } }) => {
     setError('');
     const { value } = event.target;
@@ -76,7 +80,7 @@ const VehicleDetails: FC<Props> = ({
       .then(setVehicle)
       .catch(errors => setError(formatErrors(errors)));
     setLoading(false);
-  }, [setVehicle, tempRegistration]);
+  }, [setVehicle, tempRegistration, setError]);
 
   const restrictions = vehicle ? getRestrictions(vehicle, t) : [];
 

--- a/src/common/editPermits/VehicleDetails.tsx
+++ b/src/common/editPermits/VehicleDetails.tsx
@@ -58,6 +58,7 @@ const VehicleDetails: FC<Props> = ({
   const navigate = useNavigate();
   const permitCtx = useContext(PermitStateContext);
   const [loading, setLoading] = useState(false);
+  const [processingRequest, setProcessingRequest] = useState(false);
   const [tempRegistration, setTempRegistration] = useState('');
   const errorState = useContext(ErrorStateContext);
   // type cast is used to get around some typing ugliness concerning state setter methods
@@ -81,6 +82,13 @@ const VehicleDetails: FC<Props> = ({
       .catch(errors => setError(formatErrors(errors)));
     setLoading(false);
   }, [setVehicle, tempRegistration, setError]);
+
+  const processVehicleChange = async () => {
+    setProcessingRequest(true);
+    const asyncOnContinue = async () => onContinue();
+    await asyncOnContinue();
+    setProcessingRequest(false);
+  };
 
   const restrictions = vehicle ? getRestrictions(vehicle, t) : [];
 
@@ -181,10 +189,11 @@ const VehicleDetails: FC<Props> = ({
         <Button
           theme="black"
           className="action-btn"
-          disabled={!vehicle}
+          disabled={!vehicle || loading || processingRequest}
           iconRight={<IconArrowRight />}
-          onClick={() => onContinue()}>
-          {t(`${T_PATH}.actionBtn.continue`)}
+          onClick={processVehicleChange}>
+          {!processingRequest && t(`${T_PATH}.actionBtn.continue`)}
+          {processingRequest && <LoadingSpinner small />}
         </Button>
 
         <Button

--- a/src/hooks/errorProvider.tsx
+++ b/src/hooks/errorProvider.tsx
@@ -1,0 +1,13 @@
+import React, { Dispatch, SetStateAction } from 'react';
+
+export type ErrorStateDict = {
+  error: string;
+  setError: Dispatch<SetStateAction<string>>;
+};
+
+// Undefined is used to get around initializing a Dispatch<SetStateAction<string>>-value
+// without invoking useState() outside of component context which react doesn't allow.
+// The actual value of the context is casted back to ErrorStateDict.
+type ErrorStateContextDefaultValue = ErrorStateDict | undefined;
+export const ErrorStateContext =
+  React.createContext<ErrorStateContextDefaultValue>(undefined);

--- a/src/pages/changeVehicle/ChangeVehicle.tsx
+++ b/src/pages/changeVehicle/ChangeVehicle.tsx
@@ -163,6 +163,11 @@ const ChangeVehicle = (): React.ReactElement => {
           navigate(ROUTES.VALID_PERMITS);
         } else if (checkoutUrl) {
           window.open(`${checkoutUrl}`, '_self');
+        } else {
+          // Backend might return a null checkout url on success
+          // due to price not actually changing
+          // (eg. the permits end date is less than a month away)
+          navigate(ROUTES.VALID_PERMITS);
         }
       } else if (canBeRefunded(permit)) {
         setStep(ChangeVehicleStep.PRICE_PREVIEW);

--- a/src/pages/changeVehicle/ChangeVehicle.tsx
+++ b/src/pages/changeVehicle/ChangeVehicle.tsx
@@ -172,7 +172,7 @@ const ChangeVehicle = (): React.ReactElement => {
       } else if (canBeRefunded(permit)) {
         setStep(ChangeVehicleStep.PRICE_PREVIEW);
       } else {
-        updateAndNavigateToOrderView();
+        await updateAndNavigateToOrderView();
       }
     }
   };


### PR DESCRIPTION
This PR introduces the following fixes/improvements:

- gracefully handle SHPPWS-115-related duplicate permit-exception from the backend when changing a permits vehicle permanently (changing to a temporary vehicle already handles this properly)
- display a loading spinner and disable the update-button while processing a vehicle update request
- redirect to the main page when receiving a null checkout-url when successfully updating a permits vehicle (eg. changing to a more expensive vehicle with less than a month of permit validity time left)