### PR TITLE
SHPPWS-115/fix duplicate permit error handling

### DIFF
--- a/src/common/editPermits/PriceChangePreview.tsx
+++ b/src/common/editPermits/PriceChangePreview.tsx
@@ -1,5 +1,5 @@
-import { Button, IconArrowLeft, IconArrowRight } from 'hds-react';
-import React, { Fragment } from 'react';
+import { Button, IconArrowLeft, IconArrowRight, Notification } from 'hds-react';
+import React, { Fragment, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { uniqueId } from 'lodash';
 import {
@@ -11,6 +11,10 @@ import { formatDateDisplay, formatVehicle } from '../utils';
 import { formatMonthlyPrice, formatPrice } from '../../utils';
 import './PriceChangePreview.scss';
 import { getPermitPriceTotal } from './utils';
+import {
+  ErrorStateDict,
+  VehicleChangeErrorContext,
+} from '../../hooks/vehicleChangeErrorProvider';
 
 const T_PATH = 'common.editPermits.PriceChangePreview';
 
@@ -87,6 +91,9 @@ const PriceChangePreview: React.FC<PriceChangePreviewProps> = ({
   onCancel,
 }: PriceChangePreviewProps) => {
   const { t } = useTranslation();
+  const vehicleChangeErrorCtx = useContext(
+    VehicleChangeErrorContext
+  ) as ErrorStateDict;
   const newPriceTotal = priceChangesList.reduce(
     (total, item) => total + getPermitPriceTotal(item.priceChanges, 'newPrice'),
     0
@@ -112,6 +119,12 @@ const PriceChangePreview: React.FC<PriceChangePreviewProps> = ({
 
   return (
     <div className={className}>
+      {vehicleChangeErrorCtx.error && (
+        <Notification type="error" className="error-notification">
+          {t(vehicleChangeErrorCtx.error || '')}
+        </Notification>
+      )}
+
       <div className="title">{t(`${T_PATH}.title`)}</div>
       <div className="price-change-detail">
         {priceChangesList.map(({ permit, vehicle, priceChanges }) => (

--- a/src/common/editPermits/Refund.tsx
+++ b/src/common/editPermits/Refund.tsx
@@ -4,13 +4,18 @@ import {
   IconArrowRight,
   IconInfoCircle,
   Link,
+  Notification,
   TextInput,
 } from 'hds-react';
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { isValidIBAN } from '../utils';
 import { formatPrice } from '../../utils';
 import './Refund.scss';
+import {
+  ErrorStateDict,
+  VehicleChangeErrorContext,
+} from '../../hooks/vehicleChangeErrorProvider';
 
 const T_PATH = 'common.editPermits.Refund';
 
@@ -36,9 +41,18 @@ const Refund: React.FC<RefundProps> = ({
   onConfirm,
 }: RefundProps) => {
   const { t, i18n } = useTranslation();
+  const vehicleChangeErrorCtx = useContext(
+    VehicleChangeErrorContext
+  ) as ErrorStateDict;
   const [accountNumber, setAccountNumber] = useState('');
   return (
     <div className={className}>
+      {vehicleChangeErrorCtx.error && (
+        <Notification type="error" className="error-notification">
+          {t(vehicleChangeErrorCtx.error || '')}
+        </Notification>
+      )}
+
       <div className="title">{t(`${T_PATH}.title`)}</div>
       <div className="refund-info">
         <div className="row">

--- a/src/common/editPermits/VehicleDetails.tsx
+++ b/src/common/editPermits/VehicleDetails.tsx
@@ -63,28 +63,26 @@ const VehicleDetails: FC<Props> = ({
   const [loading, setLoading] = useState(false);
   const [processingRequest, setProcessingRequest] = useState(false);
   const [tempRegistration, setTempRegistration] = useState('');
-  const errorState = useContext(VehicleChangeErrorContext);
-  // type cast is used to get around some typing ugliness concerning state setter methods
-  // and context default value initialization, see type declaration of
-  // VehicleChangeErrorContextDefaultValue for more information.
-  const { error, setError } = errorState as ErrorStateDict;
+  const vehicleChangeErrorCtx = useContext(
+    VehicleChangeErrorContext
+  ) as ErrorStateDict;
   const inputRegistration = (event: { target: { value: string } }) => {
-    setError('');
+    vehicleChangeErrorCtx.setError('');
     const { value } = event.target;
     setTempRegistration(value.toUpperCase());
     if (value && permitCtx?.permitExists(value)) {
-      setError(t(`${T_PATH}.permitExistError`));
+      vehicleChangeErrorCtx.setError(t(`${T_PATH}.permitExistError`));
     }
   };
 
   const fetchVehicleInformation = useCallback(async () => {
     setLoading(true);
-    setError('');
+    vehicleChangeErrorCtx.setError('');
     await getVehicleInformation(tempRegistration)
       .then(setVehicle)
-      .catch(errors => setError(formatErrors(errors)));
+      .catch(errors => vehicleChangeErrorCtx.setError(formatErrors(errors)));
     setLoading(false);
-  }, [setVehicle, tempRegistration, setError]);
+  }, [vehicleChangeErrorCtx, setVehicle, tempRegistration]);
 
   const processVehicleChange = async () => {
     setProcessingRequest(true);
@@ -97,9 +95,9 @@ const VehicleDetails: FC<Props> = ({
 
   return (
     <div className="vehicle-detail-component">
-      {error && (
+      {vehicleChangeErrorCtx.error && (
         <Notification type="error" className="error-notification">
-          {t(error || '')}
+          {t(vehicleChangeErrorCtx.error || '')}
         </Notification>
       )}
 
@@ -127,7 +125,7 @@ const VehicleDetails: FC<Props> = ({
       <Button
         variant="secondary"
         className="change-btn"
-        disabled={loading || !!error?.length}
+        disabled={loading || !!vehicleChangeErrorCtx.error?.length}
         onClick={fetchVehicleInformation}>
         {!loading && t(`${T_PATH}.changeBtn`)}
         {loading && <LoadingSpinner small />}

--- a/src/common/editPermits/VehicleDetails.tsx
+++ b/src/common/editPermits/VehicleDetails.tsx
@@ -33,7 +33,10 @@ import {
 } from '../../utils';
 import './vehicleDetails.scss';
 import DiscountLabel from '../discountLabel/DiscountLabel';
-import { ErrorStateContext, ErrorStateDict } from '../../hooks/errorProvider';
+import {
+  VehicleChangeErrorContext,
+  ErrorStateDict,
+} from '../../hooks/vehicleChangeErrorProvider';
 
 const T_PATH = 'common.editPermits.ChangeVehicle';
 
@@ -60,10 +63,10 @@ const VehicleDetails: FC<Props> = ({
   const [loading, setLoading] = useState(false);
   const [processingRequest, setProcessingRequest] = useState(false);
   const [tempRegistration, setTempRegistration] = useState('');
-  const errorState = useContext(ErrorStateContext);
+  const errorState = useContext(VehicleChangeErrorContext);
   // type cast is used to get around some typing ugliness concerning state setter methods
   // and context default value initialization, see type declaration of
-  // ErrorStateContextDefaultValue for more information.
+  // VehicleChangeErrorContextDefaultValue for more information.
   const { error, setError } = errorState as ErrorStateDict;
   const inputRegistration = (event: { target: { value: string } }) => {
     setError('');

--- a/src/hooks/vehicleChangeErrorProvider.tsx
+++ b/src/hooks/vehicleChangeErrorProvider.tsx
@@ -8,6 +8,6 @@ export type ErrorStateDict = {
 // Undefined is used to get around initializing a Dispatch<SetStateAction<string>>-value
 // without invoking useState() outside of component context which react doesn't allow.
 // The actual value of the context is casted back to ErrorStateDict.
-type ErrorStateContextDefaultValue = ErrorStateDict | undefined;
-export const ErrorStateContext =
-  React.createContext<ErrorStateContextDefaultValue>(undefined);
+type VehicleChangeErrorContextDefaultValue = ErrorStateDict | undefined;
+export const VehicleChangeErrorContext =
+  React.createContext<VehicleChangeErrorContextDefaultValue>(undefined);

--- a/src/hooks/vehicleChangeErrorProvider.tsx
+++ b/src/hooks/vehicleChangeErrorProvider.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction } from 'react';
+import React, { Dispatch, FC, SetStateAction, useMemo, useState } from 'react';
 
 export type ErrorStateDict = {
   error: string;
@@ -11,3 +11,25 @@ export type ErrorStateDict = {
 type VehicleChangeErrorContextDefaultValue = ErrorStateDict | undefined;
 export const VehicleChangeErrorContext =
   React.createContext<VehicleChangeErrorContextDefaultValue>(undefined);
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export const VehicleChangeErrorProvider: FC<Props> = ({ children }) => {
+  const [error, setError] = useState('');
+
+  const errorState = useMemo(
+    () => ({
+      error,
+      setError,
+    }),
+    [error, setError]
+  ) as ErrorStateDict;
+
+  return (
+    <VehicleChangeErrorContext.Provider value={errorState}>
+      {children}
+    </VehicleChangeErrorContext.Provider>
+  );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import { PermitProvider } from './hooks/permitProvider';
 import { UserProfileProvider } from './hooks/userProfileProvider';
 import './i18n/i18n';
 import reportWebVitals from './reportWebVitals';
+import { VehicleChangeErrorProvider } from './hooks/vehicleChangeErrorProvider';
 
 const ENVS_WITH_SENTRY = ['test', 'stage', 'prod'];
 
@@ -33,7 +34,9 @@ root.render(
     <HDSLoginProvider>
       <UserProfileProvider>
         <PermitProvider>
-          <App />
+          <VehicleChangeErrorProvider>
+            <App />
+          </VehicleChangeErrorProvider>
         </PermitProvider>
       </UserProfileProvider>
     </HDSLoginProvider>

--- a/src/pages/changeVehicle/ChangeVehicle.tsx
+++ b/src/pages/changeVehicle/ChangeVehicle.tsx
@@ -160,7 +160,7 @@ const ChangeVehicle = (): React.ReactElement => {
           // (eg. the permits end date is less than a month away)
           navigate(ROUTES.VALID_PERMITS);
         }
-      } else if (canBeRefunded(permit)) {
+      } else if (!VehicleChangeErrorCtx.error && canBeRefunded(permit)) {
         setStep(ChangeVehicleStep.PRICE_PREVIEW);
       } else {
         await updateAndNavigateToOrderView();
@@ -189,7 +189,7 @@ const ChangeVehicle = (): React.ReactElement => {
           onConfirm={() => {
             if (priceChangeType === PriceChangeType.NO_CHANGE) {
               updateAndNavigateToOrderView();
-            } else {
+            } else if (!VehicleChangeErrorCtx.error) {
               setStep(ChangeVehicleStep.REFUND);
             }
           }}

--- a/src/pages/changeVehicle/ChangeVehicle.tsx
+++ b/src/pages/changeVehicle/ChangeVehicle.tsx
@@ -95,9 +95,8 @@ const ChangeVehicle = (): React.ReactElement => {
       vehicleChangeErrorCtx.setError(t(`${T_PATH}.permitExistError`));
     });
 
-    await permitCtx?.fetchPermits();
-
     if (updateSuccessful) {
+      await permitCtx?.fetchPermits();
       navigate(`${ROUTES.SUCCESS}?permitId=${permit.id}`);
     }
   };

--- a/src/pages/changeVehicle/ChangeVehicle.tsx
+++ b/src/pages/changeVehicle/ChangeVehicle.tsx
@@ -24,7 +24,7 @@ import {
   calcProductUnitPrice,
   calcProductUnitVatPrice,
 } from '../../utils';
-import { ErrorStateContext } from '../../hooks/errorProvider';
+import { VehicleChangeErrorContext } from '../../hooks/vehicleChangeErrorProvider';
 
 enum PriceChangeType {
   HIGHER_PRICE = 2,
@@ -179,7 +179,7 @@ const ChangeVehicle = (): React.ReactElement => {
 
   return (
     <div className="change-vehicle-component">
-      <ErrorStateContext.Provider value={errorState}>
+      <VehicleChangeErrorContext.Provider value={errorState}>
         {step === ChangeVehicleStep.VEHICLE && (
           <VehicleDetails
             permit={permit}
@@ -190,7 +190,7 @@ const ChangeVehicle = (): React.ReactElement => {
             setLowEmissionChecked={setLowEmissionChecked}
           />
         )}
-      </ErrorStateContext.Provider>
+      </VehicleChangeErrorContext.Provider>
       {step === ChangeVehicleStep.PRICE_PREVIEW && priceChangesList && (
         <PriceChangePreview
           className="price-change-preview"


### PR DESCRIPTION
- add missing error notifications in `PriceChangePreview`- and Refund-components
- lift `VehicleChangeErrorContext.Provider` up in the component tree
- refactor logic in the `ChangeVehicle`-component
- run `fetchPermits()` only after a successful permit update
- prevent progress in the UI-flow if the context contains errors, this is to make the flow one-way only if the user goes backwards in the flow.