### PR TITLE
Release 1.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.5] - 2025-09-25
+
+### Fixed
+
+* Display an error instead of allowing duplicate permit ([7780db5](https://github.com/City-of-Helsinki/parking-permits-ui/commit/7780db5de303f8e3393aae49d5a13a80024fcbd1))
+* Redirect to front page when changing vehicle if the price does not change ([7736e52](https://github.com/City-of-Helsinki/parking-permits-ui/commit/7736e520315827c7582a5a80062993299c2ec1d0))
+* Display a loading indicator when updating permit vehicle ([1e1c132](https://github.com/City-of-Helsinki/parking-permits-ui/commit/1e1c132047ee855486c9801d98e4a2a9dd7fce38))
+* Re-fetch permits from the backend only after a successful vehicle update ([6f2416b](https://github.com/City-of-Helsinki/parking-permits-ui/commit/6f2416b69583fa768ac2515ff01d8d43130ccf0d))
+
+### Changed
+
+* Prevent progress to next step in the vehicle change UI-flow on error ([c7c14f1](https://github.com/City-of-Helsinki/parking-permits-ui/commit/c7c14f1e926373344644333edf69e67c0a738670))
+
 ## [1.4.4] - 2025-05-15
 
 ### Changed
@@ -242,5 +255,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * @dependabot made their first contribution in https://github.com/City-of-Helsinki/parking-permits-ui/pull/118
 * @snyk-bot made their first contribution in https://github.com/City-of-Helsinki/parking-permits-ui/pull/140
 * @danjacob-anders made their first contribution in https://github.com/City-of-Helsinki/parking-permits-ui/pull/186
+* @Nukasev made their first contribution in https://github.com/City-of-Helsinki/parking-permits-ui/pull/264
 
 **Full Changelog**: https://github.com/City-of-Helsinki/parking-permits-ui/commits/release-1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parking-permits-ui",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/src/common/editPermits/PriceChangePreview.tsx
+++ b/src/common/editPermits/PriceChangePreview.tsx
@@ -1,5 +1,5 @@
-import { Button, IconArrowLeft, IconArrowRight } from 'hds-react';
-import React, { Fragment } from 'react';
+import { Button, IconArrowLeft, IconArrowRight, Notification } from 'hds-react';
+import React, { Fragment, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { uniqueId } from 'lodash';
 import {
@@ -11,6 +11,10 @@ import { formatDateDisplay, formatVehicle } from '../utils';
 import { formatMonthlyPrice, formatPrice } from '../../utils';
 import './PriceChangePreview.scss';
 import { getPermitPriceTotal } from './utils';
+import {
+  ErrorStateDict,
+  VehicleChangeErrorContext,
+} from '../../hooks/vehicleChangeErrorProvider';
 
 const T_PATH = 'common.editPermits.PriceChangePreview';
 
@@ -87,6 +91,9 @@ const PriceChangePreview: React.FC<PriceChangePreviewProps> = ({
   onCancel,
 }: PriceChangePreviewProps) => {
   const { t } = useTranslation();
+  const vehicleChangeErrorCtx = useContext(
+    VehicleChangeErrorContext
+  ) as ErrorStateDict;
   const newPriceTotal = priceChangesList.reduce(
     (total, item) => total + getPermitPriceTotal(item.priceChanges, 'newPrice'),
     0
@@ -112,6 +119,12 @@ const PriceChangePreview: React.FC<PriceChangePreviewProps> = ({
 
   return (
     <div className={className}>
+      {vehicleChangeErrorCtx.error && (
+        <Notification type="error" className="error-notification">
+          {t(vehicleChangeErrorCtx.error || '')}
+        </Notification>
+      )}
+
       <div className="title">{t(`${T_PATH}.title`)}</div>
       <div className="price-change-detail">
         {priceChangesList.map(({ permit, vehicle, priceChanges }) => (

--- a/src/common/editPermits/Refund.tsx
+++ b/src/common/editPermits/Refund.tsx
@@ -4,13 +4,18 @@ import {
   IconArrowRight,
   IconInfoCircle,
   Link,
+  Notification,
   TextInput,
 } from 'hds-react';
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { isValidIBAN } from '../utils';
 import { formatPrice } from '../../utils';
 import './Refund.scss';
+import {
+  ErrorStateDict,
+  VehicleChangeErrorContext,
+} from '../../hooks/vehicleChangeErrorProvider';
 
 const T_PATH = 'common.editPermits.Refund';
 
@@ -36,9 +41,18 @@ const Refund: React.FC<RefundProps> = ({
   onConfirm,
 }: RefundProps) => {
   const { t, i18n } = useTranslation();
+  const vehicleChangeErrorCtx = useContext(
+    VehicleChangeErrorContext
+  ) as ErrorStateDict;
   const [accountNumber, setAccountNumber] = useState('');
   return (
     <div className={className}>
+      {vehicleChangeErrorCtx.error && (
+        <Notification type="error" className="error-notification">
+          {t(vehicleChangeErrorCtx.error || '')}
+        </Notification>
+      )}
+
       <div className="title">{t(`${T_PATH}.title`)}</div>
       <div className="refund-info">
         <div className="row">

--- a/src/hooks/vehicleChangeErrorProvider.tsx
+++ b/src/hooks/vehicleChangeErrorProvider.tsx
@@ -1,0 +1,35 @@
+import React, { Dispatch, FC, SetStateAction, useMemo, useState } from 'react';
+
+export type ErrorStateDict = {
+  error: string;
+  setError: Dispatch<SetStateAction<string>>;
+};
+
+// Undefined is used to get around initializing a Dispatch<SetStateAction<string>>-value
+// without invoking useState() outside of component context which react doesn't allow.
+// The actual value of the context is casted back to ErrorStateDict.
+type VehicleChangeErrorContextDefaultValue = ErrorStateDict | undefined;
+export const VehicleChangeErrorContext =
+  React.createContext<VehicleChangeErrorContextDefaultValue>(undefined);
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export const VehicleChangeErrorProvider: FC<Props> = ({ children }) => {
+  const [error, setError] = useState('');
+
+  const errorState = useMemo(
+    () => ({
+      error,
+      setError,
+    }),
+    [error, setError]
+  ) as ErrorStateDict;
+
+  return (
+    <VehicleChangeErrorContext.Provider value={errorState}>
+      {children}
+    </VehicleChangeErrorContext.Provider>
+  );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import { PermitProvider } from './hooks/permitProvider';
 import { UserProfileProvider } from './hooks/userProfileProvider';
 import './i18n/i18n';
 import reportWebVitals from './reportWebVitals';
+import { VehicleChangeErrorProvider } from './hooks/vehicleChangeErrorProvider';
 
 const ENVS_WITH_SENTRY = ['test', 'stage', 'prod'];
 
@@ -33,7 +34,9 @@ root.render(
     <HDSLoginProvider>
       <UserProfileProvider>
         <PermitProvider>
-          <App />
+          <VehicleChangeErrorProvider>
+            <App />
+          </VehicleChangeErrorProvider>
         </PermitProvider>
       </UserProfileProvider>
     </HDSLoginProvider>


### PR DESCRIPTION
## [1.4.5] - 2025-09-25

### Fixed

* Display an error instead of allowing duplicate permit ([7780db5](https://github.com/City-of-Helsinki/parking-permits-ui/commit/7780db5de303f8e3393aae49d5a13a80024fcbd1))
* Redirect to front page when changing vehicle if the price does not change ([7736e52](https://github.com/City-of-Helsinki/parking-permits-ui/commit/7736e520315827c7582a5a80062993299c2ec1d0))
* Display a loading indicator when updating permit vehicle ([1e1c132](https://github.com/City-of-Helsinki/parking-permits-ui/commit/1e1c132047ee855486c9801d98e4a2a9dd7fce38))
* Re-fetch permits from the backend only after a successful vehicle update ([6f2416b](https://github.com/City-of-Helsinki/parking-permits-ui/commit/6f2416b69583fa768ac2515ff01d8d43130ccf0d))

### Changed

* Prevent progress to next step in the vehicle change UI-flow on error ([c7c14f1](https://github.com/City-of-Helsinki/parking-permits-ui/commit/c7c14f1e926373344644333edf69e67c0a738670))