### PR TITLE
feat: make map tile URL configurable via environment variable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -19,3 +19,4 @@ REACT_APP_PARKING_PERMITS_PERMISSION="https://api.hel.fi/auth/parkingpermits#rea
 REACT_APP_ALLOWED_AGE_LIMIT=18
 REACT_APP_SENTRY_DSN=""
 REACT_APP_SENTRY_ENVIRONMENT="local-development-unconfigured"
+REACT_APP_MAP_URL_TEMPLATE="https://maptiles.api.hel.fi/styles/hel-osm-bright-{language}/{z}/{x}/{y}.png"

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ CMD ["yarn", "start"]
 FROM appbase as staticbuilder
 #==============================
 COPY . /app
+ARG REACT_APP_MAP_URL_TEMPLATE
 RUN yarn build
 
 

--- a/src/common/parkingZoneMap/ParkingZonesMap.tsx
+++ b/src/common/parkingZoneMap/ParkingZonesMap.tsx
@@ -6,6 +6,7 @@ import { GeoJSON, MapContainer, Marker, Popup, TileLayer } from 'react-leaflet';
 import { v4 as uuidv4 } from 'uuid';
 import marker from '../../assets/images/icon_poi_talo-sininen.svg';
 import { UserAddress, Zone } from '../../types';
+import { getEnv } from '../../utils';
 import './parkingZonesMap.css';
 
 const icon = new L.Icon({
@@ -50,20 +51,16 @@ export default function ParkingZonesMap({
   const center = userAddress.location as LatLngExpression;
   const attribution = 'map.attribution.helsinki';
   const getURL = (lang: string) => {
-    const suffix = lang === 'sv' ? '@sv' : '';
-    return `https://tiles.hel.ninja/styles/hel-osm-bright/{z}/{x}/{y}${suffix}.png`;
+    const template = getEnv('REACT_APP_MAP_URL_TEMPLATE');
+    const language = ['fi', 'sv'].includes(lang) ? lang : 'fi';
+    return template.replace('{language}', language);
   };
   return (
     <MapContainer
       center={flipLocation(center as number[])}
       zoom={zoom}
       attributionControl>
-      {i18n.language === 'sv' && (
-        <TileLayer attribution={t(attribution)} url={getURL(i18n.language)} />
-      )}
-      {i18n.language !== 'sv' && (
-        <TileLayer attribution={t(attribution)} url={getURL(i18n.language)} />
-      )}
+      <TileLayer attribution={t(attribution)} url={getURL(i18n.language)} />
       {userAddress && (
         <Marker position={flipLocation(center as number[])} icon={icon}>
           <Popup>{getAddressZoneInfo(userAddress, i18n.language)}</Popup>


### PR DESCRIPTION
Replace hardcoded `tiles.hel.ninja` URL with a configurable `REACT_APP_MAP_URL_TEMPLATE` environment variable using {language} placeholder.

Add ARG `REACT_APP_MAP_URL_TEMPLATE` to Dockerfile staticbuilder stage and add the variable with
the production `maptiles.api.hel.fi` URL to `.env.template`.

Refs: [PV-988](https://helsinkisolutionoffice.atlassian.net/browse/PV-988)

## Screenshots

<img width="623" height="550" alt="Pysäköintiluvat" src="https://github.com/user-attachments/assets/1bcd21c2-33fe-4e27-8e0d-1992dd5abcfd" />

<img width="573" height="510" alt="Pysäköintiluvat-sv" src="https://github.com/user-attachments/assets/befdf6c9-22cf-4292-a1b7-5f5a24c4cf68" />


[PV-988]: https://helsinkisolutionoffice.atlassian.net/browse/PV-988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ